### PR TITLE
Rewrite to use InterprocessLib

### DIFF
--- a/AudioBridge.cs
+++ b/AudioBridge.cs
@@ -30,11 +30,13 @@ public class AudioBridge : BasePlugin
     private static ConfigEntry<MuteTarget>? _muteTarget;
     private static ConfigEntry<bool>? _debugLogging;
 
+    private static bool _actualEnabled;
+
     internal static new ManualLogSource? Log;
 
     internal static bool ShouldMute => Enabled && MuteTarget == MuteTarget.Host;
     internal static MuteTarget MuteTarget => _muteTarget!.Value;
-    internal static bool Enabled => _enabled!.Value;
+    internal static bool Enabled => _actualEnabled;
     internal static bool DebugLogging => _debugLogging!.Value;
     internal static bool Ready
     {
@@ -203,23 +205,34 @@ public class AudioBridge : BasePlugin
     
     private void OnEnabledChanged()
     {
-        UniLog.Log($"[AudioBridge] Enabled changed to: {Enabled}");
+        UniLog.Log($"[AudioBridge] Enabled changed to: {_enabled!.Value}");
 
-        if (!Ready) return;
-
-        if (Enabled)
+        if (!Ready)
         {
-            if (ShadowBus.Initialized) return;
+            _actualEnabled = _enabled.Value;
+            return;
+        }
+
+        if (_enabled.Value)
+        {
+            _actualEnabled = true;
 
             UniLog.Log("[AudioBridge] Enabling audio sharing");
             ShadowWriterPatch.ResetState();
         }
-        else if (ShadowBus.Initialized)
+        else
         {
             UniLog.Log("[AudioBridge] Disabling audio sharing");
 
-            ShadowBus.Shutdown();
-            ShadowWriterPatch.UpdateSessionMuting();
+            if (ShadowBus.Initialized)
+                ShadowBus.Shutdown();
+
+            Task.Run(async () => 
+            { 
+                await Task.Delay(100);
+                _actualEnabled = false;
+                ShadowWriterPatch.UpdateSessionMuting();
+            });
         }
     }
     
@@ -434,7 +447,7 @@ internal static class ShadowWriterPatch
             if (_firstRun)
             {
                 _firstRun = false;
-                if (!ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
+                if (!ShadowBus.Initialized && !ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
                 {
                     _initFailed = true;
                     return;
@@ -443,7 +456,8 @@ internal static class ShadowWriterPatch
             }
 
             // Write audio data BEFORE muting (so renderer gets unmuted audio)
-            ShadowBus.WriteFloats(buffer.AsSpan(offset, floatsRead));
+            if (ShadowBus.Initialized)
+                ShadowBus.WriteFloats(buffer.AsSpan(offset, floatsRead));
             
             // If host should be muted, zero out the buffer AFTER sharing it
             if (AudioBridge.ShouldMute)
@@ -497,8 +511,9 @@ internal static class ShadowWriterPatch
             if (_firstRun)
             {
                 _firstRun = false;
-                if (!ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
+                if (!ShadowBus.Initialized && !ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
                 {
+                    _initFailed = true;
                     return;
                 }
                 UpdateSessionMuting();
@@ -510,9 +525,10 @@ internal static class ShadowWriterPatch
                 // It's already float data in byte form
                 var floatBuffer = new float[bytesRead / sizeof(float)];
                 Buffer.BlockCopy(buffer, offset, floatBuffer, 0, bytesRead);
-                
+
                 // Write to shared memory BEFORE muting
-                ShadowBus.WriteFloats(floatBuffer.AsSpan());
+                if (ShadowBus.Initialized)
+                    ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
                 if (AudioBridge.ShouldMute)
@@ -544,7 +560,8 @@ internal static class ShadowWriterPatch
                 }
                 
                 // Write to shared memory BEFORE muting
-                ShadowBus.WriteFloats(floatBuffer.AsSpan());
+                if (ShadowBus.Initialized)
+                    ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
                 if (AudioBridge.ShouldMute)
@@ -577,9 +594,10 @@ internal static class ShadowWriterPatch
                     sample >>= 8; // Sign extend
                     floatBuffer[i] = sample / 8388608.0f; // Convert to -1.0 to 1.0 range
                 }
-                
+
                 // Write to shared memory BEFORE muting
-                ShadowBus.WriteFloats(floatBuffer.AsSpan());
+                if (ShadowBus.Initialized)
+                    ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
                 if (AudioBridge.ShouldMute)
@@ -771,7 +789,9 @@ internal static class ShadowWriterPatch
     
     internal static void ResetState()
     {
-        UniLog.Log("[AudioBridge] Resetting shadow writer state");
+        if (AudioBridge.DebugLogging)
+            UniLog.Log("[AudioBridge] Resetting shadow writer state");
+
         _firstRun = true;
         _initFailed = false;
         _loggedFormat = false;

--- a/AudioBridge.cs
+++ b/AudioBridge.cs
@@ -30,14 +30,14 @@ public class AudioBridge : BasePlugin
     private static ConfigEntry<MuteTarget>? _muteTarget;
     private static ConfigEntry<bool>? _debugLogging;
 
-    private static bool _actualEnabled;
-
     internal static new ManualLogSource? Log;
 
     internal static bool ShouldMute => Enabled && MuteTarget == MuteTarget.Host;
+
     internal static MuteTarget MuteTarget => _muteTarget!.Value;
-    internal static bool Enabled => _actualEnabled;
+    internal static bool Enabled => _enabled!.Value;
     internal static bool DebugLogging => _debugLogging!.Value;
+
     internal static bool Ready
     {
         get
@@ -67,9 +67,9 @@ public class AudioBridge : BasePlugin
             _enabled.SettingChanged += (sender, args) => OnEnabledChanged();
             _muteTarget.SettingChanged += (sender, args) => OnMuteTargetChanged();
 
-            Log.LogInfo($"[AudioBridge] On load mute target: {MuteTarget}");
-            Log.LogInfo($"[AudioBridge] On load enabled: {Enabled}");
-            Log.LogInfo($"[AudioBridge] On load debug logging: {DebugLogging}");
+            Log.LogInfo($"[AudioBridge] On load mute target: {_muteTarget.Value}");
+            Log.LogInfo($"[AudioBridge] On load enabled: {_enabled.Value}");
+            Log.LogInfo($"[AudioBridge] On load debug logging: {_debugLogging.Value}");
 
             // Time to patch everything manually, yay!
             Log.LogInfo("[AudioBridge] Applying audio driver patches");
@@ -209,14 +209,11 @@ public class AudioBridge : BasePlugin
 
         if (!Ready)
         {
-            _actualEnabled = _enabled.Value;
             return;
         }
 
         if (_enabled.Value)
         {
-            _actualEnabled = true;
-
             UniLog.Log("[AudioBridge] Enabling audio sharing");
             ShadowWriterPatch.ResetState();
         }
@@ -226,13 +223,6 @@ public class AudioBridge : BasePlugin
 
             if (ShadowBus.Initialized)
                 ShadowBus.Shutdown();
-
-            Task.Run(async () => 
-            { 
-                await Task.Delay(100);
-                _actualEnabled = false;
-                ShadowWriterPatch.UpdateSessionMuting();
-            });
         }
     }
     
@@ -417,13 +407,18 @@ internal static class ShadowWriterPatch
     private static bool _loggedFormat = false;
     private static int _writeCounter = 0;
 
+    private static bool _patchesEnabled = true;
+    private static DateTime? _shadowBusDisabledTime = null;
+
+    private const float DEACTIVATE_TIME_SECONDS = 0.5f;
+
     // Postfix for Read(float[], int, int)
     private static void Read_Float_Postfix(CSCoreAudioOutputDriver __instance, float[] buffer, int offset, int count, ref int __result)
     {
         try
         {
             // Check if audio sharing is enabled
-            if (!AudioBridge.Enabled) return;
+            if (!_patchesEnabled) return;
             if (_initFailed) return;
             if (!AudioBridge.Ready) return;
             
@@ -476,6 +471,17 @@ internal static class ShadowWriterPatch
             {
                 UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks");
             }
+
+            if (!ShadowBus.Initialized)
+            {
+                if (_shadowBusDisabledTime is null)
+                    _shadowBusDisabledTime = DateTime.Now;
+                else if ((DateTime.Now - _shadowBusDisabledTime).Value.TotalSeconds > DEACTIVATE_TIME_SECONDS)
+                {
+                    _patchesEnabled = false;
+                    ShadowWriterPatch.UpdateSessionMuting();
+                }
+            }
         }
         catch (Exception ex) { UniLog.Error($"Audio float processing error: {ex.Message}"); }
     }
@@ -486,7 +492,7 @@ internal static class ShadowWriterPatch
         try
         {
             // Check if audio sharing is enabled
-            if (!AudioBridge.Enabled) return;
+            if (!_patchesEnabled) return;
             if (!AudioBridge.Ready) return;
             if (_initFailed) return;
             if (__result <= 0) return;
@@ -623,6 +629,17 @@ internal static class ShadowWriterPatch
                 {
                     UniLog.Log($"[AudioBridge] Unsupported audio format: {bitsPerSample}-bit");
                     _loggedUnsupported = true;
+                }
+            }
+
+            if (!ShadowBus.Initialized)
+            {
+                if (_shadowBusDisabledTime is null)
+                    _shadowBusDisabledTime = DateTime.Now;
+                else if ((DateTime.Now - _shadowBusDisabledTime).Value.TotalSeconds > DEACTIVATE_TIME_SECONDS)
+                {
+                    _patchesEnabled = false;
+                    ShadowWriterPatch.UpdateSessionMuting();
                 }
             }
         }
@@ -793,6 +810,8 @@ internal static class ShadowWriterPatch
             UniLog.Log("[AudioBridge] Resetting shadow writer state");
 
         _firstRun = true;
+        _shadowBusDisabledTime = null;
+        _patchesEnabled = true;
         _initFailed = false;
         _loggedFormat = false;
         _loggedByte = false;

--- a/AudioBridge.cs
+++ b/AudioBridge.cs
@@ -1,14 +1,15 @@
-﻿using CSCore.CoreAudioAPI;
+﻿using BepInEx;
+using BepInEx.Configuration;
+using BepInEx.NET.Common;
+using BepInExResoniteShim;
+using CSCore.CoreAudioAPI;
 using CSCore.SoundOut;
 using Elements.Core;
 using FrooxEngine;
 using HarmonyLib;
-using BepInEx;
-using BepInEx.Configuration;
-using BepInEx.NET.Common;
-using BepInExResoniteShim;
-using System.IO.MemoryMappedFiles;
-using System.Runtime.InteropServices;
+using InterprocessLib;
+using Renderite.Shared;
+using System.Threading.Channels;
 
 namespace AudioBridge;
 
@@ -185,11 +186,6 @@ public class AudioBridge : BasePlugin
                 if (ShadowBus.EnsureInit(writer: true))
                 {
                     UniLog.Log("[AudioBridge] Shared memory audio buffer initialized");
-                    // Reset buffer indices on initial start
-                    ShadowBus.ResetBufferIndices();
-                    // Explicitly publish that we're enabled
-                    ShadowBus.PublishEnabled(true);
-                    ShadowBus.PublishMuteTarget(_currentMuteTarget);
                     // Note: SessionID will be captured and written when the audio driver starts
                 }
                 else
@@ -230,11 +226,6 @@ public class AudioBridge : BasePlugin
                 {
                     UniLog.Log("[AudioBridge] Audio sharing enabled successfully");
                     
-                    // Reset buffer indices on re-enable for clean start
-                    ShadowBus.ResetBufferIndices();
-                    
-                    ShadowBus.PublishEnabled(true);
-                    
                     // Reset the writer state
                     ShadowWriterPatch.ResetState();
                     
@@ -271,9 +262,8 @@ public class AudioBridge : BasePlugin
             {
                 ShadowWriterPatch.ApplyMuteConfiguration(false);
             }
-            
-            // Publish disabled state before shutting down
-            ShadowBus.PublishEnabled(false);
+
+            ShadowBus._messenger.SendValue("enabled", false);
             
             // Wait a bit for renderer to see the change
             Task.Run(async () =>
@@ -295,8 +285,7 @@ public class AudioBridge : BasePlugin
         // Only process if enabled
         if (_isEnabled)
         {
-            // Publish the new mute target to shared memory
-            ShadowBus.PublishMuteTarget(_currentMuteTarget);
+            ShadowBus._messenger.SendValue("muteTarget", (int)_currentMuteTarget);
             
             // Update host muting based on the new target
             // Mute host if target is Host, unmute for Renderer or None
@@ -315,14 +304,55 @@ public class AudioBridge : BasePlugin
     internal static bool IsDebugLogging() => _debugLogging;
 }
 
+//internal struct ShadowBusBufferIndicies : IMemoryPackable
+//{
+//    public uint w;
+//    public uint r;
+//	public void Pack(ref MemoryPacker packer)
+//	{
+//		packer.Write(w);
+//        packer.Write(r);
+//	}
 
+//	public void Unpack(ref MemoryUnpacker unpacker)
+//	{
+//		unpacker.Read(ref w);
+//        unpacker.Read(ref r);
+//	}
+//}
+
+internal class ShadowBusData : IMemoryPackable
+{
+    public int sampleRate;
+    public int channels;
+    public int muteTarget;
+    public int enabled;
+    public string sessionId;
+    public void Pack(ref MemoryPacker packer)
+    {
+        packer.Write(sampleRate);
+        packer.Write(channels);
+        packer.Write(muteTarget);
+        packer.Write(enabled);
+        packer.Write(sessionId);
+    }
+
+    public void Unpack(ref MemoryUnpacker unpacker)
+    {
+        unpacker.Read(ref sampleRate);
+        unpacker.Read(ref channels);
+        unpacker.Read(ref muteTarget);
+        unpacker.Read(ref enabled);
+        unpacker.Read(ref sessionId);
+    }
+}
 
 // ===== Shared bus (host<->renderer) =====
 internal static class ShadowBus
 {
     // Use Local namespace (no prefix) to avoid permission issues
     private const string MMF_NAME = "AudioBridge_SharedMemory";
-    private const string MUTEX_NAME = "AudioBridge_SharedMemory_Mutex";
+    //private const string MUTEX_NAME = "AudioBridge_SharedMemory_Mutex";
 
     // Header layout (bytes)
     //  0..3  : uint writeIdx
@@ -335,19 +365,18 @@ internal static class ShadowBus
     // 60..63 : reserved
     private const int HEADER_BYTES = 64;
     private const int RING_BYTES = 2 * 1024 * 1024; // 2MB ring buffer for stable audio
-    private const int MMF_BYTES = HEADER_BYTES + RING_BYTES;
+    //private const int MMF_BYTES = HEADER_BYTES + RING_BYTES;
 
-    private static MemoryMappedFile _mmf;
-    private static MemoryMappedViewAccessor _view;
-    private static Mutex _mtx;
+    internal static Messenger _messenger;
 
-    private static volatile bool _inited;
+    //private static volatile bool _inited;
 
     public static bool EnsureInit(bool writer, int sampleRate = 48000, int channels = 2, string sessionId = null)
     {
-        if (_inited)
+        if (_messenger is not null)
         {
-            // Already initialized, return silently
+            // Already initialized
+            SendInitData(sampleRate, channels, sessionId);
             return true;
         }
         
@@ -356,101 +385,17 @@ internal static class ShadowBus
         
         try
         {
+            _messenger = new Messenger(MMF_NAME, [typeof(ShadowBusData)], []);
+
+            if (AudioBridge.IsDebugLogging())
+                UniLog.Log($"[AudioBridge] Messenger created: {MMF_NAME}");
+
             if (writer)
             {
-                if (AudioBridge.IsDebugLogging())
-                    UniLog.Log($"[AudioBridge] Creating shared memory: {MMF_NAME}");
-                _mmf = MemoryMappedFile.CreateOrOpen(MMF_NAME, MMF_BYTES, MemoryMappedFileAccess.ReadWrite);
-                if (AudioBridge.IsDebugLogging())
-                    UniLog.Log("[AudioBridge] Shared memory created");
-                
-                if (AudioBridge.IsDebugLogging())
-                    UniLog.Log($"[AudioBridge] Creating synchronization mutex: {MUTEX_NAME}");
-                _mtx = new Mutex(false, MUTEX_NAME);
-                if (AudioBridge.IsDebugLogging())
-                    UniLog.Log("[AudioBridge] Mutex created");
-                
-                _view = _mmf.CreateViewAccessor(0, MMF_BYTES, MemoryMappedFileAccess.ReadWrite);
-                if (AudioBridge.IsDebugLogging())
-                    UniLog.Log("[AudioBridge] Memory accessor created");
-                
-                _mtx.WaitOne();
-                try
-                {
-                    // If first time, zero indices and write format
-                    uint w = _view.ReadUInt32(0);
-                    uint r = _view.ReadUInt32(4);
-                    if (AudioBridge.IsDebugLogging())
-                        UniLog.Log($"[AudioBridge] Buffer indices: write={w}, read={r}");
-                    
-                    if (w > RING_BYTES || r > RING_BYTES)
-                    {
-                        UniLog.Log("[AudioBridge] Resetting buffer indices");
-                        _view.Write(0, (uint)0);
-                        _view.Write(4, (uint)0);
-                    }
-                    
-                    _view.Write(8, sampleRate);
-                    _view.Write(12, channels);
-                    _view.Write(16, (int)AudioBridge.GetCurrentMuteTarget());
-                    _view.Write(20, AudioBridge.IsEnabled() ? 1 : 0);
-                    
-                    // Write SessionID if provided
-                    if (!string.IsNullOrEmpty(sessionId))
-                    {
-                        WriteSessionId(sessionId);
-                    }
-                    
-                    if (AudioBridge.IsDebugLogging())
-                        UniLog.Log($"[AudioBridge] Audio format: {sampleRate}Hz, {channels} channels, SessionID: {sessionId ?? "none"}");
-                }
-                finally { _mtx.ReleaseMutex(); }
-            }
-            else
-            {
-                UniLog.Log($"[AudioBridge] Opening shared memory: {MMF_NAME}");
-                
-                // For reader, try to wait for writer to create the MMF first
-                bool mmfExists = false;
-                Exception lastError = null;
-                
-                for (int attempt = 0; attempt < 10; attempt++)
-                {
-                    try
-                    {
-                        _mmf = MemoryMappedFile.OpenExisting(MMF_NAME, MemoryMappedFileRights.ReadWrite);
-                        mmfExists = true;
-                        UniLog.Log($"[AudioBridge] Shared memory opened on attempt {attempt + 1}");
-                        break;
-                    }
-                    catch (Exception ex)
-                    {
-                        lastError = ex;
-                        if (attempt < 9)
-                        {
-                            if (AudioBridge.IsDebugLogging())
-                            UniLog.Log($"[AudioBridge] Waiting for shared memory (attempt {attempt + 1}/10)");
-                            Thread.Sleep(500);
-                        }
-                    }
-                }
-                
-                if (!mmfExists)
-                {
-                    UniLog.Error($"[AudioBridge] Failed to open shared memory: {lastError?.Message}");
-                    throw new InvalidOperationException($"MMF {MMF_NAME} not found", lastError);
-                }
-                
-                UniLog.Log($"[AudioBridge] Opening synchronization mutex");
-                _mtx = Mutex.OpenExisting(MUTEX_NAME);
-                UniLog.Log("[AudioBridge] Mutex opened");
-                
-                _view = _mmf.CreateViewAccessor(0, MMF_BYTES, MemoryMappedFileAccess.ReadWrite);
-                UniLog.Log("[AudioBridge] Memory accessor created");
+                SendInitData(sampleRate, channels, sessionId);
             }
             
-            _inited = true;
-            UniLog.Log("[AudioBridge] Shared memory initialization complete");
+            UniLog.Log("[AudioBridge] Initialization complete");
             return true;
         }
         catch (Exception ex)
@@ -458,259 +403,114 @@ internal static class ShadowBus
             UniLog.Error($"[AudioBridge] Shared memory initialization failed: {ex.Message}");
             UniLog.Error($"[AudioBridge] Stack trace: {ex.StackTrace}");
             
-            // Clean up on failure
-            try { _view?.Dispose(); } catch { }
-            try { _mtx?.Dispose(); } catch { }
-            try { _mmf?.Dispose(); } catch { }
-            _view = null;
-            _mtx = null;
-            _mmf = null;
+            _messenger = null;
             
             return false;
         }
     }
 
-    public static void WriteSessionId(string sessionId)
+    private static void SendInitData(int sampleRate = 48000, int channels = 2, string sessionId = null)
     {
-        if (!_inited || string.IsNullOrEmpty(sessionId)) return;
-        
-        _mtx.WaitOne();
-        try
-        {
-            // Clear the SessionID area first
-            byte[] clearBytes = new byte[36];
-            _view.WriteArray(24, clearBytes, 0, 36);
-            
-            // Write the SessionID string (up to 36 chars)
-            byte[] sessionBytes = System.Text.Encoding.ASCII.GetBytes(sessionId);
-            int writeLength = Math.Min(sessionBytes.Length, 36);
-            _view.WriteArray(24, sessionBytes, 0, writeLength);
-            if (AudioBridge.IsDebugLogging())
-                UniLog.Log($"[AudioBridge] Written SessionID to shared memory: {sessionId}");
-        }
-        finally { _mtx.ReleaseMutex(); }
-    }
-    
-    public static string ReadSessionId()
-    {
-        if (!_inited) return null;
-        
-        _mtx.WaitOne();
-        try
-        {
-            byte[] sessionBytes = new byte[36];
-            _view.ReadArray(24, sessionBytes, 0, 36);
-            
-            // Find null terminator
-            int length = Array.IndexOf(sessionBytes, (byte)0);
-            if (length == -1) length = 36;
-            if (length == 0) return null;
-            
-            return System.Text.Encoding.ASCII.GetString(sessionBytes, 0, length);
-        }
-        finally { _mtx.ReleaseMutex(); }
-    }
-    
-    public static void PublishFormat(int sampleRate, int channels, string sessionId = null)
-    {
-        if (!_inited) return;
-        _mtx.WaitOne();
-        try
-        {
-            if (AudioBridge.IsDebugLogging())
-                UniLog.Log($"[AudioBridge] Publishing audio format: {sampleRate}Hz, {channels}ch, SessionID: {sessionId ?? "none"}");
-            _view.Write(8, sampleRate);
-            _view.Write(12, channels);
-            _view.Write(16, (int)AudioBridge.GetCurrentMuteTarget());
-            
-            if (!string.IsNullOrEmpty(sessionId))
-            {
-                WriteSessionId(sessionId);
-            }
-        }
-        finally { _mtx.ReleaseMutex(); }
-    }
-    
-    public static void PublishMuteTarget(MuteTarget target)
-    {
-        if (!_inited) return;
-        _mtx.WaitOne();
-        try
-        {
-            _view.Write(16, (int)target);
-            if (AudioBridge.IsDebugLogging())
-                UniLog.Log($"[AudioBridge] Published mute target: {target}");
-        }
-        finally { _mtx.ReleaseMutex(); }
-    }
+        var muteTarget = AudioBridge.GetCurrentMuteTarget();
 
-    public static (int sampleRate, int channels) ReadFormat()
-    {
-        if (!_inited) return (48000, 2);
-        _mtx.WaitOne();
-        try
-        {
-            // Reading audio format
-            int sr = _view.ReadInt32(8);
-            int ch = _view.ReadInt32(12);
-            if (sr <= 0 || ch <= 0) return (48000, 2);
-            return (sr, ch);
-        }
-        finally { _mtx.ReleaseMutex(); }
-    }
-    
-    public static MuteTarget ReadMuteTarget()
-    {
-        if (!_inited) return MuteTarget.Renderer;
-        _mtx.WaitOne();
-        try
-        {
-            int muteValue = _view.ReadInt32(16);
-            if (muteValue < 0 || muteValue > 2) return MuteTarget.Renderer;
-            return (MuteTarget)muteValue;
-        }
-        finally { _mtx.ReleaseMutex(); }
-    }
-    
-    public static void PublishEnabled(bool enabled)
-    {
-        if (!_inited) return;
-        _mtx.WaitOne();
-        try
-        {
-            _view.Write(20, enabled ? 1 : 0);
-            
-            // Reset ring buffer indices when disabling to ensure clean restart
-            if (!enabled)
-            {
-                _view.Write(0, (uint)0);  // Reset write index
-                _view.Write(4, (uint)0);  // Reset read index
-                if (AudioBridge.IsDebugLogging())
-                    UniLog.Log("[AudioBridge] Reset buffer indices on disable");
-            }
-            
-            if (AudioBridge.IsDebugLogging())
-                UniLog.Log($"[AudioBridge] Published enabled state: {enabled}");
-        }
-        finally { _mtx.ReleaseMutex(); }
-    }
-    
-    public static bool ReadEnabled()
-    {
-        if (!_inited) return false;
-        _mtx.WaitOne();
-        try
-        {
-            return _view.ReadInt32(20) == 1;
-        }
-        finally { _mtx.ReleaseMutex(); }
-    }
-    
-    public static void ResetBufferIndices()
-    {
-        if (!_inited) return;
-        _mtx.WaitOne();
-        try
-        {
-            _view.Write(0, (uint)0);  // Reset write index
-            _view.Write(4, (uint)0);  // Reset read index
-            if (AudioBridge.IsDebugLogging())
-                UniLog.Log("[AudioBridge] Buffer indices reset to 0");
-        }
-        finally { _mtx.ReleaseMutex(); }
+        var initData = new ShadowBusData();
+        initData.sampleRate = sampleRate;
+        initData.channels = channels;
+        initData.muteTarget = (int)muteTarget;
+        initData.enabled = AudioBridge.IsEnabled() ? 1 : 0;
+        initData.sessionId = sessionId;
+        _messenger.SendObject("initData", initData);
+
+        if (AudioBridge.IsDebugLogging())
+            UniLog.Log($"[AudioBridge] Audio format: {sampleRate}Hz, {channels} channels, muteTarget: {muteTarget}, enabled: {initData.enabled}, SessionID: {sessionId ?? "none"}");
     }
     
     public static void Shutdown()
     {
-        if (!_inited) return;
+        if (_messenger is null) return;
         
         UniLog.Log("[AudioBridge] Shutting down shared memory");
-        _inited = false;
         
-        try { _view?.Dispose(); } catch { }
-        try { _mtx?.Dispose(); } catch { }
-        try { _mmf?.Dispose(); } catch { }
-        
-        _view = null;
-        _mtx = null;
-        _mmf = null;
+        _messenger = null;
     }
 
     // Writer: float32 interleaved -> ring
     public static void WriteFloats(ReadOnlySpan<float> src)
     {
-        if (!_inited || src.IsEmpty) return;
+        if (src.IsEmpty) return;
 
-        var srcBytes = MemoryMarshal.AsBytes(src);
+        _messenger?.SendValueList("floats", src.ToArray().ToList()); // ToDo: optimize this
 
-        _mtx.WaitOne();
-        try
-        {
-            uint w = _view.ReadUInt32(0);
-            uint r = _view.ReadUInt32(4);
+        //var srcBytes = MemoryMarshal.AsBytes(src);
 
-            int free = (int)((RING_BYTES + r - w - 1) % RING_BYTES);
-            int want = Math.Min(free, srcBytes.Length);
-            if (want <= 0) return;
+        //_mtx.WaitOne();
+        //try
+        //{
+        //    //uint w = _view.ReadUInt32(0);
+        //    //uint r = _view.ReadUInt32(4);
 
-            int headOffset = HEADER_BYTES + (int)w;
-            int tail = Math.Min(want, RING_BYTES - (int)w);
+        //    int free = (int)((RING_BYTES + r - w - 1) % RING_BYTES);
+        //    int want = Math.Min(free, srcBytes.Length);
+        //    if (want <= 0) return;
 
-            _view.WriteArray(headOffset, srcBytes[..tail].ToArray(), 0, tail);
-            if (want > tail)
-            {
-                _view.WriteArray(HEADER_BYTES, srcBytes[tail..want].ToArray(), 0, want - tail);
-            }
+        //    int headOffset = HEADER_BYTES + (int)w;
+        //    int tail = Math.Min(want, RING_BYTES - (int)w);
 
-            w = (uint)((w + want) % RING_BYTES);
-            _view.Write(0, w);
-        }
-        finally { _mtx.ReleaseMutex(); }
+        //    _view.WriteArray(headOffset, srcBytes[..tail].ToArray(), 0, tail);
+        //    if (want > tail)
+        //    {
+        //        _view.WriteArray(HEADER_BYTES, srcBytes[tail..want].ToArray(), 0, want - tail);
+        //    }
+
+        //    w = (uint)((w + want) % RING_BYTES);
+        //    _view.Write(0, w);
+        //}
+        //finally { _mtx.ReleaseMutex(); }
     }
 
     // Reader: fill dst with float32 interleaved from ring; returns samples (floats) read
-    public static int ReadFloats(Span<float> dst)
-    {
-        if (!_inited || dst.IsEmpty) return 0;
+    //public static int ReadFloats(Span<float> dst)
+    //{
+    //    if (!_inited || dst.IsEmpty) return 0;
 
-        var dstBytes = MemoryMarshal.AsBytes(dst);
-        int gotBytes = 0;
+    //    var dstBytes = MemoryMarshal.AsBytes(dst);
+    //    int gotBytes = 0;
 
-        _mtx.WaitOne();
-        try
-        {
-            uint w = _view.ReadUInt32(0);
-            uint r = _view.ReadUInt32(4);
+    //    _mtx.WaitOne();
+    //    try
+    //    {
+    //        uint w = _view.ReadUInt32(0);
+    //        uint r = _view.ReadUInt32(4);
 
-            int avail = (int)((RING_BYTES + w - r) % RING_BYTES);
-            if (avail <= 0) return 0;
+    //        int avail = (int)((RING_BYTES + w - r) % RING_BYTES);
+    //        if (avail <= 0) return 0;
 
-            int want = Math.Min(avail, dstBytes.Length);
-            int headOffset = HEADER_BYTES + (int)r;
-            int tail = Math.Min(want, RING_BYTES - (int)r);
+    //        int want = Math.Min(avail, dstBytes.Length);
+    //        int headOffset = HEADER_BYTES + (int)r;
+    //        int tail = Math.Min(want, RING_BYTES - (int)r);
 
-            // First segment
-            var tmp = new byte[tail];
-            _view.ReadArray(headOffset, tmp, 0, tail);
-            tmp.CopyTo(dstBytes);
+    //        // First segment
+    //        var tmp = new byte[tail];
+    //        _view.ReadArray(headOffset, tmp, 0, tail);
+    //        tmp.CopyTo(dstBytes);
 
-            // Wrapped segment
-            if (want > tail)
-            {
-                int rest = want - tail;
-                var tmp2 = new byte[rest];
-                _view.ReadArray(HEADER_BYTES, tmp2, 0, rest);
-                tmp2.CopyTo(dstBytes[tail..]);
-            }
+    //        // Wrapped segment
+    //        if (want > tail)
+    //        {
+    //            int rest = want - tail;
+    //            var tmp2 = new byte[rest];
+    //            _view.ReadArray(HEADER_BYTES, tmp2, 0, rest);
+    //            tmp2.CopyTo(dstBytes[tail..]);
+    //        }
 
-            r = (uint)((r + want) % RING_BYTES);
-            _view.Write(4, r);
-            gotBytes = want;
-        }
-        finally { _mtx.ReleaseMutex(); }
+    //        r = (uint)((r + want) % RING_BYTES);
+    //        _view.Write(4, r);
+    //        gotBytes = want;
+    //    }
+    //    finally { _mtx.ReleaseMutex(); }
 
-        return gotBytes / sizeof(float); // floats read
-    }
+    //    return gotBytes / sizeof(float); // floats read
+    //}
 }
 
 // ===== Writer patch (Host process) =====
@@ -755,7 +555,7 @@ internal static class ShadowWriterPatch
             {
                 if (ShadowBus.EnsureInit(writer: true, sampleRate: fmt.SampleRate, channels: fmt.Channels, sessionId: _capturedSessionId))
                 {
-                    ShadowBus.PublishFormat(fmt.SampleRate, fmt.Channels, _capturedSessionId);
+                    //ShadowBus.PublishFormat(fmt.SampleRate, fmt.Channels, _capturedSessionId);
                     _busInitialized = true;
                     UniLog.Log("[AudioBridge] Shared memory initialized for audio streaming");
                 }
@@ -817,7 +617,7 @@ internal static class ShadowWriterPatch
             {
                 if (ShadowBus.EnsureInit(writer: true, sampleRate: sampleRate, channels: channels, sessionId: _capturedSessionId))
                 {
-                    ShadowBus.PublishFormat(sampleRate, channels, _capturedSessionId);
+                    //ShadowBus.PublishFormat(sampleRate, channels, _capturedSessionId);
                     _busInitialized = true;
                     UniLog.Log("[AudioBridge] Shared memory initialized for audio streaming");
                 }
@@ -980,11 +780,11 @@ internal static class ShadowWriterPatch
                                         _capturedSessionId = sessionId.ToString();
                                         if (AudioBridge.IsDebugLogging())
                                             UniLog.Log($"[AudioBridge] Captured Engine SessionID: {_capturedSessionId}");
-                                        
+
                                         // If bus is already initialized, update the SessionID
                                         if (_busInitialized && _capturedSessionId != null)
                                         {
-                                            ShadowBus.WriteSessionId(_capturedSessionId);
+                                            ShadowBus._messenger?.SendString("sessionId", _capturedSessionId);
                                         }
                                     }
                                 }

--- a/AudioBridge.cs
+++ b/AudioBridge.cs
@@ -9,7 +9,6 @@ using FrooxEngine;
 using HarmonyLib;
 using InterprocessLib;
 using Renderite.Shared;
-using System.Threading.Channels;
 
 namespace AudioBridge;
 
@@ -263,7 +262,7 @@ public class AudioBridge : BasePlugin
                 ShadowWriterPatch.ApplyMuteConfiguration(false);
             }
 
-            ShadowBus._messenger.SendValue("enabled", false);
+            ShadowBus.Messenger!.SendValue("enabled", false);
             
             // Wait a bit for renderer to see the change
             Task.Run(async () =>
@@ -285,7 +284,7 @@ public class AudioBridge : BasePlugin
         // Only process if enabled
         if (_isEnabled)
         {
-            ShadowBus._messenger.SendValue("muteTarget", (int)_currentMuteTarget);
+            ShadowBus.Messenger!.SendValue("muteTarget", (int)_currentMuteTarget);
             
             // Update host muting based on the new target
             // Mute host if target is Host, unmute for Renderer or None
@@ -304,37 +303,47 @@ public class AudioBridge : BasePlugin
     internal static bool IsDebugLogging() => _debugLogging;
 }
 
-//internal struct ShadowBusBufferIndicies : IMemoryPackable
-//{
-//    public uint w;
-//    public uint r;
-//	public void Pack(ref MemoryPacker packer)
-//	{
-//		packer.Write(w);
-//        packer.Write(r);
-//	}
+internal class ShadowBusFloatsData : IMemoryPackable
+{
+    public float[]? data;
 
-//	public void Unpack(ref MemoryUnpacker unpacker)
-//	{
-//		unpacker.Read(ref w);
-//        unpacker.Read(ref r);
-//	}
-//}
+	public void Pack(ref MemoryPacker packer)
+	{
+        packer.Write(data!.Length);
+		foreach (var flt in data!)
+        {
+			packer.Write(flt);
+		}
+	}
 
-internal class ShadowBusData : IMemoryPackable
+	public void Unpack(ref MemoryUnpacker unpacker)
+	{
+		int len = 0;
+        unpacker.Read(ref len);
+        data = new float[len];
+        for (int i = 0; i < len; i++)
+        {
+            float flt = 0f;
+            unpacker.Read(ref flt);
+            data[i] = flt;
+        }
+	}
+}
+
+internal class ShadowBusInitData : IMemoryPackable
 {
     public int sampleRate;
     public int channels;
     public int muteTarget;
     public int enabled;
-    public string sessionId;
+    public string? sessionId;
     public void Pack(ref MemoryPacker packer)
     {
         packer.Write(sampleRate);
         packer.Write(channels);
         packer.Write(muteTarget);
         packer.Write(enabled);
-        packer.Write(sessionId);
+        packer.Write(sessionId!);
     }
 
     public void Unpack(ref MemoryUnpacker unpacker)
@@ -343,37 +352,20 @@ internal class ShadowBusData : IMemoryPackable
         unpacker.Read(ref channels);
         unpacker.Read(ref muteTarget);
         unpacker.Read(ref enabled);
-        unpacker.Read(ref sessionId);
+        unpacker.Read(ref sessionId!);
     }
 }
 
 // ===== Shared bus (host<->renderer) =====
 internal static class ShadowBus
 {
-    // Use Local namespace (no prefix) to avoid permission issues
-    private const string MMF_NAME = "AudioBridge_SharedMemory";
-    //private const string MUTEX_NAME = "AudioBridge_SharedMemory_Mutex";
+    private const string MESSENGER_NAME = "AudioBridge";
 
-    // Header layout (bytes)
-    //  0..3  : uint writeIdx
-    //  4..7  : uint readIdx
-    //  8..11 : int sampleRate
-    // 12..15 : int channels
-    // 16..19 : int muteTarget (0=None, 1=Host, 2=Renderer)
-    // 20..23 : int enabled (0=disabled, 1=enabled)
-    // 24..59 : string sessionId (36 bytes for GUID string)
-    // 60..63 : reserved
-    private const int HEADER_BYTES = 64;
-    private const int RING_BYTES = 2 * 1024 * 1024; // 2MB ring buffer for stable audio
-    //private const int MMF_BYTES = HEADER_BYTES + RING_BYTES;
+    internal static Messenger? Messenger;
 
-    internal static Messenger _messenger;
-
-    //private static volatile bool _inited;
-
-    public static bool EnsureInit(bool writer, int sampleRate = 48000, int channels = 2, string sessionId = null)
+    public static bool EnsureInit(bool writer, int sampleRate = 48000, int channels = 2, string? sessionId = null)
     {
-        if (_messenger is not null)
+        if (Messenger is not null)
         {
             // Already initialized
             SendInitData(sampleRate, channels, sessionId);
@@ -385,10 +377,10 @@ internal static class ShadowBus
         
         try
         {
-            _messenger = new Messenger(MMF_NAME, [typeof(ShadowBusData)], []);
+            Messenger = new Messenger(MESSENGER_NAME, [typeof(ShadowBusInitData), typeof(ShadowBusFloatsData)], []);
 
             if (AudioBridge.IsDebugLogging())
-                UniLog.Log($"[AudioBridge] Messenger created: {MMF_NAME}");
+                UniLog.Log($"[AudioBridge] Messenger created: {MESSENGER_NAME}");
 
             if (writer)
             {
@@ -403,23 +395,23 @@ internal static class ShadowBus
             UniLog.Error($"[AudioBridge] Shared memory initialization failed: {ex.Message}");
             UniLog.Error($"[AudioBridge] Stack trace: {ex.StackTrace}");
             
-            _messenger = null;
+            Messenger = null;
             
             return false;
         }
     }
 
-    private static void SendInitData(int sampleRate = 48000, int channels = 2, string sessionId = null)
+    private static void SendInitData(int sampleRate = 48000, int channels = 2, string? sessionId = null)
     {
         var muteTarget = AudioBridge.GetCurrentMuteTarget();
 
-        var initData = new ShadowBusData();
+        var initData = new ShadowBusInitData();
         initData.sampleRate = sampleRate;
         initData.channels = channels;
         initData.muteTarget = (int)muteTarget;
         initData.enabled = AudioBridge.IsEnabled() ? 1 : 0;
         initData.sessionId = sessionId;
-        _messenger.SendObject("initData", initData);
+        Messenger!.SendObject("initData", initData);
 
         if (AudioBridge.IsDebugLogging())
             UniLog.Log($"[AudioBridge] Audio format: {sampleRate}Hz, {channels} channels, muteTarget: {muteTarget}, enabled: {initData.enabled}, SessionID: {sessionId ?? "none"}");
@@ -427,11 +419,11 @@ internal static class ShadowBus
     
     public static void Shutdown()
     {
-        if (_messenger is null) return;
+        if (Messenger is null) return;
         
         UniLog.Log("[AudioBridge] Shutting down shared memory");
         
-        _messenger = null;
+        Messenger = null;
     }
 
     // Writer: float32 interleaved -> ring
@@ -439,78 +431,10 @@ internal static class ShadowBus
     {
         if (src.IsEmpty) return;
 
-        _messenger?.SendValueList("floats", src.ToArray().ToList()); // ToDo: optimize this
-
-        //var srcBytes = MemoryMarshal.AsBytes(src);
-
-        //_mtx.WaitOne();
-        //try
-        //{
-        //    //uint w = _view.ReadUInt32(0);
-        //    //uint r = _view.ReadUInt32(4);
-
-        //    int free = (int)((RING_BYTES + r - w - 1) % RING_BYTES);
-        //    int want = Math.Min(free, srcBytes.Length);
-        //    if (want <= 0) return;
-
-        //    int headOffset = HEADER_BYTES + (int)w;
-        //    int tail = Math.Min(want, RING_BYTES - (int)w);
-
-        //    _view.WriteArray(headOffset, srcBytes[..tail].ToArray(), 0, tail);
-        //    if (want > tail)
-        //    {
-        //        _view.WriteArray(HEADER_BYTES, srcBytes[tail..want].ToArray(), 0, want - tail);
-        //    }
-
-        //    w = (uint)((w + want) % RING_BYTES);
-        //    _view.Write(0, w);
-        //}
-        //finally { _mtx.ReleaseMutex(); }
+        var floatsData = new ShadowBusFloatsData();
+        floatsData.data = src.ToArray();
+		Messenger?.SendObject<ShadowBusFloatsData>("floats", floatsData); // ToDo: optimize this, allocating new arrays and lists constantly is bad
     }
-
-    // Reader: fill dst with float32 interleaved from ring; returns samples (floats) read
-    //public static int ReadFloats(Span<float> dst)
-    //{
-    //    if (!_inited || dst.IsEmpty) return 0;
-
-    //    var dstBytes = MemoryMarshal.AsBytes(dst);
-    //    int gotBytes = 0;
-
-    //    _mtx.WaitOne();
-    //    try
-    //    {
-    //        uint w = _view.ReadUInt32(0);
-    //        uint r = _view.ReadUInt32(4);
-
-    //        int avail = (int)((RING_BYTES + w - r) % RING_BYTES);
-    //        if (avail <= 0) return 0;
-
-    //        int want = Math.Min(avail, dstBytes.Length);
-    //        int headOffset = HEADER_BYTES + (int)r;
-    //        int tail = Math.Min(want, RING_BYTES - (int)r);
-
-    //        // First segment
-    //        var tmp = new byte[tail];
-    //        _view.ReadArray(headOffset, tmp, 0, tail);
-    //        tmp.CopyTo(dstBytes);
-
-    //        // Wrapped segment
-    //        if (want > tail)
-    //        {
-    //            int rest = want - tail;
-    //            var tmp2 = new byte[rest];
-    //            _view.ReadArray(HEADER_BYTES, tmp2, 0, rest);
-    //            tmp2.CopyTo(dstBytes[tail..]);
-    //        }
-
-    //        r = (uint)((r + want) % RING_BYTES);
-    //        _view.Write(4, r);
-    //        gotBytes = want;
-    //    }
-    //    finally { _mtx.ReleaseMutex(); }
-
-    //    return gotBytes / sizeof(float); // floats read
-    //}
 }
 
 // ===== Writer patch (Host process) =====
@@ -555,7 +479,6 @@ internal static class ShadowWriterPatch
             {
                 if (ShadowBus.EnsureInit(writer: true, sampleRate: fmt.SampleRate, channels: fmt.Channels, sessionId: _capturedSessionId))
                 {
-                    //ShadowBus.PublishFormat(fmt.SampleRate, fmt.Channels, _capturedSessionId);
                     _busInitialized = true;
                     UniLog.Log("[AudioBridge] Shared memory initialized for audio streaming");
                 }
@@ -617,7 +540,6 @@ internal static class ShadowWriterPatch
             {
                 if (ShadowBus.EnsureInit(writer: true, sampleRate: sampleRate, channels: channels, sessionId: _capturedSessionId))
                 {
-                    //ShadowBus.PublishFormat(sampleRate, channels, _capturedSessionId);
                     _busInitialized = true;
                     UniLog.Log("[AudioBridge] Shared memory initialized for audio streaming");
                 }
@@ -784,7 +706,7 @@ internal static class ShadowWriterPatch
                                         // If bus is already initialized, update the SessionID
                                         if (_busInitialized && _capturedSessionId != null)
                                         {
-                                            ShadowBus._messenger?.SendString("sessionId", _capturedSessionId);
+                                            ShadowBus.Messenger?.SendString("sessionId", _capturedSessionId);
                                         }
                                     }
                                 }

--- a/AudioBridge.cs
+++ b/AudioBridge.cs
@@ -307,18 +307,18 @@ internal class ShadowBusFloatsData : IMemoryPackable
 {
     public float[]? data;
 
-	public void Pack(ref MemoryPacker packer)
-	{
+    public void Pack(ref MemoryPacker packer)
+    {
         packer.Write(data!.Length);
-		foreach (var flt in data!)
+        foreach (var flt in data!)
         {
-			packer.Write(flt);
-		}
-	}
+            packer.Write(flt);
+        }
+    }
 
-	public void Unpack(ref MemoryUnpacker unpacker)
-	{
-		int len = 0;
+    public void Unpack(ref MemoryUnpacker unpacker)
+    {
+        int len = 0;
         unpacker.Read(ref len);
         data = new float[len];
         for (int i = 0; i < len; i++)
@@ -327,7 +327,7 @@ internal class ShadowBusFloatsData : IMemoryPackable
             unpacker.Read(ref flt);
             data[i] = flt;
         }
-	}
+    }
 }
 
 internal class ShadowBusInitData : IMemoryPackable
@@ -433,7 +433,7 @@ internal static class ShadowBus
 
         var floatsData = new ShadowBusFloatsData();
         floatsData.data = src.ToArray();
-		Messenger?.SendObject<ShadowBusFloatsData>("floats", floatsData); // ToDo: optimize this, allocating new arrays and lists constantly is bad
+        Messenger?.SendObject<ShadowBusFloatsData>("floats", floatsData); // ToDo: optimize this, allocating new arrays and lists constantly is bad
     }
 }
 

--- a/AudioBridge.cs
+++ b/AudioBridge.cs
@@ -1,5 +1,6 @@
 ﻿using BepInEx;
 using BepInEx.Configuration;
+using BepInEx.Logging;
 using BepInEx.NET.Common;
 using BepInExResoniteShim;
 using CSCore.CoreAudioAPI;
@@ -29,6 +30,8 @@ public class AudioBridge : BasePlugin
     private static ConfigEntry<MuteTarget> MUTE_TARGET;
     private static ConfigEntry<bool> DEBUG_LOGGING;
 
+    private static new ManualLogSource? Log;
+
     private static MuteTarget _currentMuteTarget = MuteTarget.Host;
     private static bool _isEnabled = false;
     private static bool _debugLogging = false;
@@ -37,11 +40,13 @@ public class AudioBridge : BasePlugin
     {
         try
         {
+            Log = base.Log;
+
             ENABLED = Config.Bind("General", "Enabled", true, "Enable audio sharing to renderer process?");
             MUTE_TARGET = Config.Bind("General", "MuteTarget", MuteTarget.Host, "Which process to mute (prevents double audio)?");
             DEBUG_LOGGING = Config.Bind("General", "DebugLogging", false, "Enable debug/verbose logging?");
             
-            UniLog.Log("[AudioBridge] Initializing audio sharing module");
+            Log.LogInfo("[AudioBridge] Plugin loading!");
             
             _currentMuteTarget = MUTE_TARGET.Value;
             _isEnabled = ENABLED.Value;
@@ -51,10 +56,10 @@ public class AudioBridge : BasePlugin
             ENABLED.SettingChanged += (sender, args) => OnEnabledChanged();
             MUTE_TARGET.SettingChanged += (sender, args) => OnMuteTargetChanged();
             DEBUG_LOGGING.SettingChanged += (sender, args) => _debugLogging = DEBUG_LOGGING.Value;
-            UniLog.Log($"[AudioBridge] Mute target set to: {_currentMuteTarget}");
-            
+            Log.LogInfo($"[AudioBridge] Mute target set to: {_currentMuteTarget}");
+
             // Time to patch everything manually, yay!
-            UniLog.Log("[AudioBridge] Applying audio driver patches");
+            Log.LogInfo("[AudioBridge] Applying audio driver patches");
             var harmony = HarmonyInstance;
             
             try
@@ -68,7 +73,7 @@ public class AudioBridge : BasePlugin
                 int patchedCount = 0;
                 
                 if (_debugLogging)
-                    UniLog.Log($"[AudioBridge] Found {methods.Length} audio driver methods");
+                    Log.LogInfo($"[AudioBridge] Found {methods.Length} audio driver methods");
                 
                 foreach (var method in methods)
                 {
@@ -78,7 +83,7 @@ public class AudioBridge : BasePlugin
                         var parameters = method.GetParameters();
                         var paramInfo = string.Join(", ", parameters.Select(p => $"{p.ParameterType.Name} {p.Name}"));
                         if (_debugLogging)
-                            UniLog.Log($"[AudioBridge] Discovered audio method: {method.Name}({paramInfo})");
+                            Log.LogInfo($"[AudioBridge] Discovered audio method: {method.Name}({paramInfo})");
                         
                         // Try to patch each Read method with the appropriate postfix
                         if (method.DeclaringType == driverType)
@@ -112,20 +117,20 @@ public class AudioBridge : BasePlugin
                                     {
                                         harmony.Patch(method, postfix: new HarmonyMethod(postfix));
                                         if (_debugLogging)
-                                            UniLog.Log($"[AudioBridge] Successfully patched {method.Name}");
+                                            Log.LogInfo($"[AudioBridge] Successfully patched {method.Name}");
                                         patchedCount++;
                                     }
                                     else
                                     {
                                         if (_debugLogging)
-                                            UniLog.Log($"[AudioBridge] Patch method {postfixName} not found");
+                                            Log.LogInfo($"[AudioBridge] Patch method {postfixName} not found");
                                     }
                                 }
                             }
                             catch (Exception patchEx)
                             {
                                 if (_debugLogging)
-                                    UniLog.Log($"[AudioBridge] Failed to patch {method.Name}: {patchEx.Message}");
+                                    Log.LogError($"[AudioBridge] Failed to patch {method.Name}: {patchEx.Message}");
                             }
                         }
                     }
@@ -134,7 +139,7 @@ public class AudioBridge : BasePlugin
                 // Also check base class methods
                 var baseMethods = baseType.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
                 if (_debugLogging)
-                    UniLog.Log($"[AudioBridge] Base driver has {baseMethods.Length} methods");
+                    Log.LogInfo($"[AudioBridge] Base driver has {baseMethods.Length} methods");
                 
                 foreach (var method in baseMethods)
                 {
@@ -143,7 +148,7 @@ public class AudioBridge : BasePlugin
                         var parameters = method.GetParameters();
                         var paramInfo = string.Join(", ", parameters.Select(p => $"{p.ParameterType.Name} {p.Name}"));
                         if (_debugLogging)
-                            UniLog.Log($"[AudioBridge] Found base method: {method.Name}({paramInfo})");
+                            Log.LogInfo($"[AudioBridge] Found base method: {method.Name}({paramInfo})");
                         
                         // Patch Start method from base class
                         if (method.Name == "Start" && method.DeclaringType == baseType)
@@ -153,54 +158,35 @@ public class AudioBridge : BasePlugin
                                 var startPostfix = typeof(ShadowWriterPatch).GetMethod("Start_Base_Postfix",
                                     System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
                                 harmony.Patch(method, postfix: new HarmonyMethod(startPostfix));
-                                UniLog.Log("[AudioBridge] Patched base Start method");
+                                Log.LogInfo("[AudioBridge] Patched base Start method");
                             }
                             catch (Exception patchEx)
                             {
-                                UniLog.Log($"[AudioBridge] Failed to patch base Start: {patchEx.Message}");
+                                Log.LogError($"[AudioBridge] Failed to patch base Start: {patchEx.Message}");
                             }
                         }
                     }
                 }
                 
                 if (_debugLogging)
-                    UniLog.Log($"[AudioBridge] Successfully patched {patchedCount} audio methods");
+                    Log.LogInfo($"[AudioBridge] Successfully patched {patchedCount} audio methods");
             }
             catch (Exception ex)
             {
-                UniLog.Error($"[AudioBridge] Patching failed: {ex.Message}");
+                Log.LogError($"[AudioBridge] Patching failed: {ex.Message}");
             }
-            
-            UniLog.Log("[AudioBridge] Audio driver patching completed");
+
+            Log.LogInfo("[AudioBridge] Audio driver patching completed");
 
             // Check if enabled in config
-            UniLog.Log($"[AudioBridge] Audio sharing enabled: {_isEnabled}");
-            
-            if (_isEnabled)
-            {
-                UniLog.Log("[AudioBridge] Initializing audio writer for host process");
-                
-                // Initialize the bus as writer immediately
-                UniLog.Log("[AudioBridge] Initializing shared memory audio buffer");
-                if (ShadowBus.EnsureInit(writer: true))
-                {
-                    UniLog.Log("[AudioBridge] Shared memory audio buffer initialized");
-                    // Note: SessionID will be captured and written when the audio driver starts
-                }
-                else
-                {
-                    UniLog.Error("[AudioBridge] Failed to initialize shared memory buffer");
-                }
-            }
-            else
-            {
-                UniLog.Log("[AudioBridge] Audio sharing is disabled");
-            }
+            Log.LogInfo($"[AudioBridge] Audio sharing enabled: {_isEnabled}");
+
+            ShadowBus.CreateMessenger();
         }
         catch (Exception ex)
         {
-            UniLog.Error($"[AudioBridge] Initialization failed: {ex.Message}");
-            UniLog.Error($"[AudioBridge] Stack trace: {ex.StackTrace}");
+            Log.LogError($"[AudioBridge] Initialization failed: {ex.Message}");
+            Log.LogError($"[AudioBridge] Stack trace: {ex.StackTrace}");
         }
     }
 
@@ -212,7 +198,7 @@ public class AudioBridge : BasePlugin
     {
         var previousEnabled = _isEnabled;
         _isEnabled = ENABLED.Value;
-        UniLog.Log($"[AudioBridge] Audio sharing enabled changed from {previousEnabled} to {_isEnabled}");
+        UniLog.Log($"[AudioBridge] Enabled changed from {previousEnabled} to {_isEnabled}");
         
         if (_isEnabled && !previousEnabled)
         {
@@ -221,33 +207,33 @@ public class AudioBridge : BasePlugin
             Task.Run(async () =>
             {
                 await Task.Delay(100); // Small delay
-                if (ShadowBus.EnsureInit(writer: true))
+                if (true)//ShadowBus.InitAudio()) // ???
                 {
                     UniLog.Log("[AudioBridge] Audio sharing enabled successfully");
-                    
+
                     // Reset the writer state
-                    ShadowWriterPatch.ResetState();
-                    
+                    ShadowWriterPatch.ResetState(); // this will result in ShadowBus.Init being called
+
                     // Apply mute configuration if needed
-                    if (_currentMuteTarget == MuteTarget.Host)
-                    {
-                        // Try to apply mute configuration with a slight delay if audio device isn't ready
-                        Task.Run(async () =>
-                        {
-                            for (int i = 0; i < 10; i++)
-                            {
-                                if (ShadowWriterPatch.TryApplyMuteConfiguration(true))
-                                {
-                                    break;
-                                }
-                                await Task.Delay(500);
-                            }
-                        });
-                    }
+                    //if (_currentMuteTarget == MuteTarget.Host)
+                    //{
+                    //	// Try to apply mute configuration with a slight delay if audio device isn't ready
+                    //	Task.Run(async () =>
+                    //	{
+                    //		for (int i = 0; i < 10; i++)
+                    //		{
+                    //			if (ShadowWriterPatch.TryApplyMuteConfiguration(true))
+                    //			{
+                    //				break;
+                    //			}
+                    //			await Task.Delay(500);
+                    //		}
+                    //	});
+                    //}
                 }
                 else
                 {
-                    UniLog.Error("[AudioBridge] Failed to enable audio sharing");
+                    UniLog.Log("[AudioBridge] Failed to enable audio sharing");
                 }
             });
         }
@@ -255,23 +241,22 @@ public class AudioBridge : BasePlugin
         {
             // Disabling audio sharing
             UniLog.Log("[AudioBridge] Disabling audio sharing...");
-            
-            // Unmute host if it was muted
-            if (_currentMuteTarget == MuteTarget.Host)
-            {
-                ShadowWriterPatch.ApplyMuteConfiguration(false);
-            }
 
-            ShadowBus.Messenger!.SendValue("enabled", false);
-            
+            ShadowWriterPatch.TryApplySessionMuting(false);
+
+            ShadowBus.Messenger!.SendEmptyCommand("stop");
+
+            ShadowWriterPatch.ResetState();
+
+            UniLog.Log("[AudioBridge] Audio sharing disabled");
+
             // Wait a bit for renderer to see the change
-            Task.Run(async () =>
-            {
-                await Task.Delay(500);
-                ShadowBus.Shutdown();
-                ShadowWriterPatch.ResetState();
-                UniLog.Log("[AudioBridge] Audio sharing disabled");
-            });
+            //Task.Run(async () =>
+            //{
+            //    await Task.Delay(500); // needed?
+            //    ShadowWriterPatch.ResetState();
+            //    UniLog.Log("[AudioBridge] Audio sharing disabled");
+            //});
         }
     }
     
@@ -285,16 +270,8 @@ public class AudioBridge : BasePlugin
         if (_isEnabled)
         {
             ShadowBus.Messenger!.SendValue("muteTarget", (int)_currentMuteTarget);
-            
-            // Update host muting based on the new target
-            // Mute host if target is Host, unmute for Renderer or None
-            bool shouldMuteHost = (_currentMuteTarget == MuteTarget.Host);
-            
-            // Only apply if there's an actual change in host muting state
-            if (previousTarget == MuteTarget.Host || _currentMuteTarget == MuteTarget.Host)
-            {
-                ShadowWriterPatch.ApplyMuteConfiguration(shouldMuteHost);
-            }
+
+            ShadowWriterPatch.TryApplySessionMuting(_currentMuteTarget == MuteTarget.Host);
         }
     }
     
@@ -335,14 +312,12 @@ internal class ShadowBusInitData : IMemoryPackable
     public int sampleRate;
     public int channels;
     public int muteTarget;
-    public int enabled;
     public string? sessionId;
     public void Pack(ref MemoryPacker packer)
     {
         packer.Write(sampleRate);
         packer.Write(channels);
         packer.Write(muteTarget);
-        packer.Write(enabled);
         packer.Write(sessionId!);
     }
 
@@ -351,7 +326,6 @@ internal class ShadowBusInitData : IMemoryPackable
         unpacker.Read(ref sampleRate);
         unpacker.Read(ref channels);
         unpacker.Read(ref muteTarget);
-        unpacker.Read(ref enabled);
         unpacker.Read(ref sessionId!);
     }
 }
@@ -361,69 +335,39 @@ internal static class ShadowBus
 {
     private const string MESSENGER_NAME = "AudioBridge";
 
-    internal static Messenger? Messenger;
+    public static Messenger? Messenger;
 
-    public static bool EnsureInit(bool writer, int sampleRate = 48000, int channels = 2, string? sessionId = null)
+    public static void CreateMessenger()
     {
-        if (Messenger is not null)
-        {
-            // Already initialized
-            SendInitData(sampleRate, channels, sessionId);
-            return true;
-        }
-        
+        Messenger = new Messenger(MESSENGER_NAME, [typeof(ShadowBusInitData), typeof(ShadowBusFloatsData)], []);
+
         if (AudioBridge.IsDebugLogging())
-            UniLog.Log($"[AudioBridge] Initializing shared memory as {(writer ? "writer" : "reader")}");
-        
+            UniLog.Log($"[AudioBridge] Messenger created: {MESSENGER_NAME}");
+    }
+
+    public static bool InitAudio(int sampleRate = 48000, int channels = 2, string? sessionId = null)
+    {
         try
         {
-            Messenger = new Messenger(MESSENGER_NAME, [typeof(ShadowBusInitData), typeof(ShadowBusFloatsData)], []);
+            var initData = new ShadowBusInitData();
+            initData.sampleRate = sampleRate;
+            initData.channels = channels;
+            initData.muteTarget = (int)AudioBridge.GetCurrentMuteTarget();
+            initData.sessionId = sessionId;
+            Messenger!.SendObject("initData", initData);
 
             if (AudioBridge.IsDebugLogging())
-                UniLog.Log($"[AudioBridge] Messenger created: {MESSENGER_NAME}");
+                UniLog.Log($"[AudioBridge] Sent init data: {sampleRate}Hz, {channels} channels, muteTarget: {initData.muteTarget}, SessionID: {sessionId ?? "none"}");
 
-            if (writer)
-            {
-                SendInitData(sampleRate, channels, sessionId);
-            }
-            
-            UniLog.Log("[AudioBridge] Initialization complete");
+            ShadowWriterPatch.TryApplySessionMuting(initData.muteTarget == (int)MuteTarget.Host);
+
             return true;
         }
         catch (Exception ex)
         {
-            UniLog.Error($"[AudioBridge] Shared memory initialization failed: {ex.Message}");
-            UniLog.Error($"[AudioBridge] Stack trace: {ex.StackTrace}");
-            
-            Messenger = null;
-            
+            UniLog.Error($"[AudioBridge] Audio initialization failed: {ex.Message}");
             return false;
         }
-    }
-
-    private static void SendInitData(int sampleRate = 48000, int channels = 2, string? sessionId = null)
-    {
-        var muteTarget = AudioBridge.GetCurrentMuteTarget();
-
-        var initData = new ShadowBusInitData();
-        initData.sampleRate = sampleRate;
-        initData.channels = channels;
-        initData.muteTarget = (int)muteTarget;
-        initData.enabled = AudioBridge.IsEnabled() ? 1 : 0;
-        initData.sessionId = sessionId;
-        Messenger!.SendObject("initData", initData);
-
-        if (AudioBridge.IsDebugLogging())
-            UniLog.Log($"[AudioBridge] Audio format: {sampleRate}Hz, {channels} channels, muteTarget: {muteTarget}, enabled: {initData.enabled}, SessionID: {sessionId ?? "none"}");
-    }
-    
-    public static void Shutdown()
-    {
-        if (Messenger is null) return;
-        
-        UniLog.Log("[AudioBridge] Shutting down shared memory");
-        
-        Messenger = null;
     }
 
     // Writer: float32 interleaved -> ring
@@ -432,8 +376,8 @@ internal static class ShadowBus
         if (src.IsEmpty) return;
 
         var floatsData = new ShadowBusFloatsData();
-        floatsData.data = src.ToArray();
-        Messenger?.SendObject<ShadowBusFloatsData>("floats", floatsData); // ToDo: optimize this, allocating new arrays and lists constantly is bad
+        floatsData.data = src.ToArray(); // Is there a way to avoid allocating an array here?
+        Messenger?.SendObject("floats", floatsData);
     }
 }
 
@@ -444,10 +388,9 @@ internal static class ShadowWriterPatch
         _fOut = AccessTools.FieldRefAccess<CSCoreAudioOutputDriver, WasapiOut>("_out");
     
     private static bool _busInitialized = false;
-    private static WasapiOut _currentAudioOutput = null;
+    private static WasapiOut? _currentAudioOutput = null;
     private static bool _isMuted = false;
-    private static string _capturedSessionId = null;
-    private static bool _shouldMuteHostAudio = false;
+    private static string? _capturedSessionId = null;
     
     // Postfix for Read(float[], int, int)
     private static void Read_Float_Postfix(CSCoreAudioOutputDriver __instance, float[] buffer, int offset, int count, ref int __result)
@@ -477,10 +420,10 @@ internal static class ShadowWriterPatch
             // Initialize shared memory only once
             if (!_busInitialized)
             {
-                if (ShadowBus.EnsureInit(writer: true, sampleRate: fmt.SampleRate, channels: fmt.Channels, sessionId: _capturedSessionId))
+                if (ShadowBus.InitAudio(sampleRate: fmt.SampleRate, channels: fmt.Channels, sessionId: _capturedSessionId))
                 {
                     _busInitialized = true;
-                    UniLog.Log("[AudioBridge] Shared memory initialized for audio streaming");
+                    UniLog.Log("[AudioBridge] Initialized audio");
                 }
                 else
                 {
@@ -492,7 +435,7 @@ internal static class ShadowWriterPatch
             ShadowBus.WriteFloats(buffer.AsSpan(offset, floatsRead));
             
             // If host should be muted, zero out the buffer AFTER sharing it
-            if (_shouldMuteHostAudio && AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
+            if (AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
             {
                 Array.Clear(buffer, offset, floatsRead);
             }
@@ -538,10 +481,10 @@ internal static class ShadowWriterPatch
             // Initialize shared memory only once
             if (!_busInitialized)
             {
-                if (ShadowBus.EnsureInit(writer: true, sampleRate: sampleRate, channels: channels, sessionId: _capturedSessionId))
+                if (ShadowBus.InitAudio(sampleRate: sampleRate, channels: channels, sessionId: _capturedSessionId))
                 {
                     _busInitialized = true;
-                    UniLog.Log("[AudioBridge] Shared memory initialized for audio streaming");
+                    UniLog.Log("[AudioBridge] Initialized audio");
                 }
                 else
                 {
@@ -560,7 +503,7 @@ internal static class ShadowWriterPatch
                 ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
-                if (_shouldMuteHostAudio && AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
+                if (AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
                 {
                     Array.Clear(buffer, offset, bytesRead);
                 }
@@ -587,7 +530,7 @@ internal static class ShadowWriterPatch
                 ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
-                if (_shouldMuteHostAudio && AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
+                if (AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
                 {
                     Array.Clear(buffer, offset, bytesRead);
                 }
@@ -617,7 +560,7 @@ internal static class ShadowWriterPatch
                 ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
-                if (_shouldMuteHostAudio && AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
+                if (AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
                 {
                     Array.Clear(buffer, offset, bytesRead);
                 }
@@ -648,7 +591,6 @@ internal static class ShadowWriterPatch
     {
         try
         {
-            
             // Log that ReadAuto was called
             if (!_loggedAuto && AudioBridge.IsDebugLogging())
             {
@@ -706,7 +648,7 @@ internal static class ShadowWriterPatch
                                         // If bus is already initialized, update the SessionID
                                         if (_busInitialized && _capturedSessionId != null)
                                         {
-                                            ShadowBus.Messenger?.SendString("sessionId", _capturedSessionId);
+                                            ShadowBus.Messenger?.SendString("sessionId", _capturedSessionId); // doesn't do anything
                                         }
                                     }
                                 }
@@ -742,11 +684,11 @@ internal static class ShadowWriterPatch
                         
                         // Store reference and apply muting if needed
                         _currentAudioOutput = outp;
-                        if (AudioBridge.IsEnabled() && AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
-                        {
-                            UniLog.Log("[AudioBridge] Applying Host mute configuration on audio start");
-                            ApplyMuteConfiguration(true);
-                        }
+                        //if (AudioBridge.IsEnabled() && AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
+                        //{
+                        //    UniLog.Log("[AudioBridge] Applying Host mute configuration on audio start");
+                        //    TryApplyMuteConfiguration(true);
+                        //}
                     }
                 }
             }
@@ -760,33 +702,28 @@ internal static class ShadowWriterPatch
     private static bool _loggedFormat = false;
     private static int _writeCounter = 0;
     
-    internal static bool TryApplyMuteConfiguration(bool shouldMute)
-    {
-        if (_currentAudioOutput == null || _currentAudioOutput.Device == null)
-        {
-            UniLog.Log("[AudioBridge] No audio device available to mute/unmute yet");
-            return false;
-        }
+    //internal static bool TryApplyMuteConfiguration(bool shouldMute)
+    //{
+    //    if (_currentAudioOutput == null || _currentAudioOutput.Device == null)
+    //    {
+    //        UniLog.Log("[AudioBridge] No audio device available to mute/unmute yet");
+    //        return false;
+    //    }
         
-        ApplyMuteConfiguration(shouldMute);
-        return true;
-    }
+    //    ApplyMuteConfiguration(shouldMute);
+    //    return true;
+    //}
     
-    internal static void ApplyMuteConfiguration(bool shouldMute)
+    internal static void TryApplySessionMuting(bool shouldMute)
     {
-        // Set the flag for buffer-level muting as primary approach
-        _shouldMuteHostAudio = shouldMute;
-        UniLog.Log($"[AudioBridge] Host audio buffer muting {(shouldMute ? "enabled" : "disabled")}");
-        
-        // Also try session-level muting as secondary approach
-        if (_currentAudioOutput == null || _currentAudioOutput.Device == null)
-        {
-            UniLog.Log("[AudioBridge] No audio device available for session muting (buffer muting will still work)");
-            return;
-        }
-        
         try
         {
+            if (_currentAudioOutput == null || _currentAudioOutput.Device == null)
+            {
+                UniLog.Log("[AudioBridge] No audio device available for session muting (buffer muting will still work)");
+                return;
+            }
+
             using var sessionManager = AudioSessionManager2.FromMMDevice(_currentAudioOutput.Device);
             using var sessionEnumerator = sessionManager.GetSessionEnumerator();
             var currentProcessId = (uint)System.Diagnostics.Process.GetCurrentProcess().Id;

--- a/AudioBridge.cs
+++ b/AudioBridge.cs
@@ -26,11 +26,11 @@ public enum MuteTarget
 [BepInDependency(BepInExResoniteShim.PluginMetadata.GUID, BepInDependency.DependencyFlags.HardDependency)]
 public class AudioBridge : BasePlugin
 {
-    private static ConfigEntry<bool> ENABLED;
-    private static ConfigEntry<MuteTarget> MUTE_TARGET;
-    private static ConfigEntry<bool> DEBUG_LOGGING;
+    private static ConfigEntry<bool>? ENABLED;
+    private static ConfigEntry<MuteTarget>? MUTE_TARGET;
+    private static ConfigEntry<bool>? DEBUG_LOGGING;
 
-    private static new ManualLogSource? Log;
+    internal static new ManualLogSource? Log;
 
     private static MuteTarget _currentMuteTarget = MuteTarget.Host;
     private static bool _isEnabled = false;
@@ -56,7 +56,10 @@ public class AudioBridge : BasePlugin
             ENABLED.SettingChanged += (sender, args) => OnEnabledChanged();
             MUTE_TARGET.SettingChanged += (sender, args) => OnMuteTargetChanged();
             DEBUG_LOGGING.SettingChanged += (sender, args) => _debugLogging = DEBUG_LOGGING.Value;
-            Log.LogInfo($"[AudioBridge] Mute target set to: {_currentMuteTarget}");
+
+            Log.LogInfo($"[AudioBridge] On load mute target: {_currentMuteTarget}");
+            Log.LogInfo($"[AudioBridge] On load enabled: {_isEnabled}");
+            Log.LogInfo($"[AudioBridge] On load debug logging: {_isEnabled}");
 
             // Time to patch everything manually, yay!
             Log.LogInfo("[AudioBridge] Applying audio driver patches");
@@ -90,7 +93,7 @@ public class AudioBridge : BasePlugin
                         {
                             try
                             {
-                                string postfixName = null;
+                                string? postfixName = null;
                                 
                                 // Choose the right postfix based on method signature
                                 if (method.Name == "Read" && parameters.Length == 3)
@@ -178,14 +181,11 @@ public class AudioBridge : BasePlugin
 
             Log.LogInfo("[AudioBridge] Audio driver patching completed");
 
-            // Check if enabled in config
-            Log.LogInfo($"[AudioBridge] Audio sharing enabled: {_isEnabled}");
-
             ShadowBus.CreateMessenger();
         }
         catch (Exception ex)
         {
-            Log.LogError($"[AudioBridge] Initialization failed: {ex.Message}");
+            Log!.LogError($"[AudioBridge] Initialization failed: {ex.Message}");
             Log.LogError($"[AudioBridge] Stack trace: {ex.StackTrace}");
         }
     }
@@ -196,88 +196,48 @@ public class AudioBridge : BasePlugin
     
     private void OnEnabledChanged()
     {
-        var previousEnabled = _isEnabled;
-        _isEnabled = ENABLED.Value;
-        UniLog.Log($"[AudioBridge] Enabled changed from {previousEnabled} to {_isEnabled}");
-        
-        if (_isEnabled && !previousEnabled)
+        var prevEnabled = _isEnabled;
+        _isEnabled = ENABLED!.Value;
+
+		UniLog.Log($"[AudioBridge] Enabled changed from {prevEnabled} to {_isEnabled}");
+
+		if (_isEnabled && !prevEnabled)
         {
             // Enabling audio sharing
             UniLog.Log("[AudioBridge] Enabling audio sharing...");
-            Task.Run(async () =>
-            {
-                await Task.Delay(100); // Small delay
-                if (true)//ShadowBus.InitAudio()) // ???
-                {
-                    UniLog.Log("[AudioBridge] Audio sharing enabled successfully");
-
-                    // Reset the writer state
-                    ShadowWriterPatch.ResetState(); // this will result in ShadowBus.Init being called
-
-                    // Apply mute configuration if needed
-                    //if (_currentMuteTarget == MuteTarget.Host)
-                    //{
-                    //	// Try to apply mute configuration with a slight delay if audio device isn't ready
-                    //	Task.Run(async () =>
-                    //	{
-                    //		for (int i = 0; i < 10; i++)
-                    //		{
-                    //			if (ShadowWriterPatch.TryApplyMuteConfiguration(true))
-                    //			{
-                    //				break;
-                    //			}
-                    //			await Task.Delay(500);
-                    //		}
-                    //	});
-                    //}
-                }
-                else
-                {
-                    UniLog.Log("[AudioBridge] Failed to enable audio sharing");
-                }
-            });
+            ShadowWriterPatch.ResetState();
         }
-        else if (!_isEnabled && previousEnabled)
+        else if (!_isEnabled && prevEnabled)
         {
             // Disabling audio sharing
             UniLog.Log("[AudioBridge] Disabling audio sharing...");
 
-            ShadowWriterPatch.TryApplySessionMuting(false);
-
-            ShadowBus.Messenger!.SendEmptyCommand("stop");
-
-            ShadowWriterPatch.ResetState();
+            ShadowBus.Shutdown();
+            ShadowWriterPatch.UpdateSessionMuting();
 
             UniLog.Log("[AudioBridge] Audio sharing disabled");
-
-            // Wait a bit for renderer to see the change
-            //Task.Run(async () =>
-            //{
-            //    await Task.Delay(500); // needed?
-            //    ShadowWriterPatch.ResetState();
-            //    UniLog.Log("[AudioBridge] Audio sharing disabled");
-            //});
         }
     }
     
     private void OnMuteTargetChanged()
     {
         var previousTarget = _currentMuteTarget;
-        _currentMuteTarget = MUTE_TARGET.Value;
+        _currentMuteTarget = MUTE_TARGET!.Value;
         UniLog.Log($"[AudioBridge] Mute target changed from {previousTarget} to {_currentMuteTarget}");
         
         // Only process if enabled
         if (_isEnabled)
         {
-            ShadowBus.Messenger!.SendValue("muteTarget", (int)_currentMuteTarget);
-
-            ShadowWriterPatch.TryApplySessionMuting(_currentMuteTarget == MuteTarget.Host);
+            if (ShadowBus.Initialized)
+                ShadowBus.SendMuteTarget(_currentMuteTarget);
+            ShadowWriterPatch.UpdateSessionMuting();
         }
     }
     
     internal static MuteTarget GetCurrentMuteTarget() => _currentMuteTarget;
     internal static bool IsEnabled() => _isEnabled;
     internal static bool IsDebugLogging() => _debugLogging;
+    internal static bool ShouldMute() => _isEnabled && _currentMuteTarget == MuteTarget.Host;
 }
 
 internal class ShadowBusFloatsData : IMemoryPackable
@@ -335,49 +295,90 @@ internal static class ShadowBus
 {
     private const string MESSENGER_NAME = "AudioBridge";
 
-    public static Messenger? Messenger;
+    private static Messenger? _messenger = null;
+
+    public static bool Initialized { get; private set; } = false;
 
     public static void CreateMessenger()
     {
-        Messenger = new Messenger(MESSENGER_NAME, [typeof(ShadowBusInitData), typeof(ShadowBusFloatsData)], []);
+        if (_messenger is not null)
+            throw new InvalidOperationException("Messenger has already been created!");
+
+        _messenger = new Messenger(MESSENGER_NAME, [typeof(ShadowBusInitData), typeof(ShadowBusFloatsData)], []);
 
         if (AudioBridge.IsDebugLogging())
-            UniLog.Log($"[AudioBridge] Messenger created: {MESSENGER_NAME}");
+            AudioBridge.Log!.LogInfo($"[AudioBridge] Messenger created: {MESSENGER_NAME}");
     }
 
-    public static bool InitAudio(int sampleRate = 48000, int channels = 2, string? sessionId = null)
+    public static bool Init(int sampleRate = 48000, int channels = 2, string? sessionId = null)
     {
-        try
+        if (_messenger is null)
+            throw new InvalidOperationException("The messenger must be created first!");
+
+		if (Initialized)
+			throw new InvalidOperationException("Already initialized!");
+
+		try
         {
             var initData = new ShadowBusInitData();
             initData.sampleRate = sampleRate;
             initData.channels = channels;
             initData.muteTarget = (int)AudioBridge.GetCurrentMuteTarget();
             initData.sessionId = sessionId;
-            Messenger!.SendObject("initData", initData);
+            _messenger!.SendObject("initData", initData);
+
+            Initialized = true;
 
             if (AudioBridge.IsDebugLogging())
-                UniLog.Log($"[AudioBridge] Sent init data: {sampleRate}Hz, {channels} channels, muteTarget: {initData.muteTarget}, SessionID: {sessionId ?? "none"}");
-
-            ShadowWriterPatch.TryApplySessionMuting(initData.muteTarget == (int)MuteTarget.Host);
+                UniLog.Log($"[AudioBridge] Sent init data: {initData.sampleRate}Hz, {initData.channels} channels, muteTarget: {initData.muteTarget}, SessionID: {initData.sessionId ?? "none"}");
 
             return true;
         }
         catch (Exception ex)
         {
             UniLog.Error($"[AudioBridge] Audio initialization failed: {ex.Message}");
+            Initialized = false;
             return false;
         }
     }
 
-    // Writer: float32 interleaved -> ring
+    public static void Shutdown()
+    {
+        if (_messenger is null)
+            throw new InvalidOperationException("The messenger must be created first!");
+
+		if (!Initialized)
+			throw new InvalidOperationException("Cannot shutdown when not initialized!");
+
+		_messenger!.SendEmptyCommand("stop");
+
+        Initialized = false;
+    }
+
     public static void WriteFloats(ReadOnlySpan<float> src)
     {
+        if (_messenger is null)
+            throw new InvalidOperationException("The messenger must be created first!");
+
+        if (!Initialized)
+            throw new InvalidOperationException("Cannot write floats when not initialized!");
+
         if (src.IsEmpty) return;
 
         var floatsData = new ShadowBusFloatsData();
-        floatsData.data = src.ToArray(); // Is there a way to avoid allocating an array here?
-        Messenger?.SendObject("floats", floatsData);
+        floatsData.data = src.ToArray(); // Is it possible to avoid allocating an array here?
+        _messenger!.SendObject("floats", floatsData);
+    }
+
+    public static void SendMuteTarget(MuteTarget muteTarget)
+    {
+        if (_messenger is null)
+            throw new InvalidOperationException("The messenger must be created first!");
+
+		if (!Initialized)
+			throw new InvalidOperationException("Cannot send mute target when not initialized!");
+
+		_messenger!.SendValue("muteTarget", (int)muteTarget);
     }
 }
 
@@ -387,11 +388,21 @@ internal static class ShadowWriterPatch
     private static readonly AccessTools.FieldRef<CSCoreAudioOutputDriver, WasapiOut>
         _fOut = AccessTools.FieldRefAccess<CSCoreAudioOutputDriver, WasapiOut>("_out");
     
-    private static bool _busInitialized = false;
     private static WasapiOut? _currentAudioOutput = null;
-    private static bool _isMuted = false;
+
+    private static bool _isSessionMuted = false;
+
+    private static bool _firstRun = true;
+
     private static string? _capturedSessionId = null;
-    
+
+    internal static bool _loggedBufferMuted = false;
+    private static bool _loggedUnsupported = false;
+    private static bool _loggedByte = false;
+    private static bool _loggedAuto = false;
+    private static bool _loggedFormat = false;
+    private static int _writeCounter = 0;
+
     // Postfix for Read(float[], int, int)
     private static void Read_Float_Postfix(CSCoreAudioOutputDriver __instance, float[] buffer, int offset, int count, ref int __result)
     {
@@ -417,27 +428,32 @@ internal static class ShadowWriterPatch
             int floatsRead = Math.Max(0, __result / sizeof(float));
             if (floatsRead == 0) return;
 
-            // Initialize shared memory only once
-            if (!_busInitialized)
+            if (_firstRun)
             {
-                if (ShadowBus.InitAudio(sampleRate: fmt.SampleRate, channels: fmt.Channels, sessionId: _capturedSessionId))
-                {
-                    _busInitialized = true;
-                    UniLog.Log("[AudioBridge] Initialized audio");
-                }
-                else
+                _firstRun = false;
+                if (!ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
                 {
                     return;
                 }
+                ShadowWriterPatch.UpdateSessionMuting();
             }
-            
+            else if (!ShadowBus.Initialized)
+            {
+                return;
+            }
+
             // Write audio data BEFORE muting (so renderer gets unmuted audio)
             ShadowBus.WriteFloats(buffer.AsSpan(offset, floatsRead));
             
             // If host should be muted, zero out the buffer AFTER sharing it
-            if (AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
+            if (AudioBridge.ShouldMute())
             {
                 Array.Clear(buffer, offset, floatsRead);
+                if (!_loggedBufferMuted && AudioBridge.IsDebugLogging())
+                {
+                    _loggedBufferMuted = true;
+                    UniLog.Log($"[AudioBridge] Buffer muted");
+                }
             }
             
             // Log periodically
@@ -477,23 +493,23 @@ internal static class ShadowWriterPatch
             int sampleRate = fmt.SampleRate;
             int channels = fmt.Channels;
             int bitsPerSample = fmt.BitsPerSample;
-            
-            // Initialize shared memory only once
-            if (!_busInitialized)
+
+            if (_firstRun)
             {
-                if (ShadowBus.InitAudio(sampleRate: sampleRate, channels: channels, sessionId: _capturedSessionId))
-                {
-                    _busInitialized = true;
-                    UniLog.Log("[AudioBridge] Initialized audio");
-                }
-                else
+                _firstRun = false;
+                if (!ShadowBus.Init(sampleRate: sampleRate, channels: channels, sessionId: _capturedSessionId))
                 {
                     return;
                 }
+                ShadowWriterPatch.UpdateSessionMuting();
             }
-            
-            // Convert bytes to float based on bit depth
-            if (bitsPerSample == 32)
+			else if (!ShadowBus.Initialized)
+			{
+				return;
+			}
+
+			// Convert bytes to float based on bit depth
+			if (bitsPerSample == 32)
             {
                 // It's already float data in byte form
                 var floatBuffer = new float[bytesRead / sizeof(float)];
@@ -503,9 +519,14 @@ internal static class ShadowWriterPatch
                 ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
-                if (AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
+                if (AudioBridge.ShouldMute())
                 {
                     Array.Clear(buffer, offset, bytesRead);
+                    if (!_loggedBufferMuted && AudioBridge.IsDebugLogging())
+                    {
+                        _loggedBufferMuted = true;
+                        UniLog.Log($"[AudioBridge] Buffer muted");
+                    }
                 }
                 
                 _writeCounter++;
@@ -530,9 +551,14 @@ internal static class ShadowWriterPatch
                 ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
-                if (AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
+                if (AudioBridge.ShouldMute())
                 {
                     Array.Clear(buffer, offset, bytesRead);
+                    if (!_loggedBufferMuted && AudioBridge.IsDebugLogging())
+                    {
+                        _loggedBufferMuted = true;
+                        UniLog.Log($"[AudioBridge] Buffer muted");
+                    }
                 }
                 
                 _writeCounter++;
@@ -560,9 +586,14 @@ internal static class ShadowWriterPatch
                 ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
-                if (AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
+                if (AudioBridge.ShouldMute())
                 {
                     Array.Clear(buffer, offset, bytesRead);
+                    if (!_loggedBufferMuted && AudioBridge.IsDebugLogging())
+                    {
+                        _loggedBufferMuted = true;
+                        UniLog.Log($"[AudioBridge] Buffer muted");
+                    }
                 }
                 
                 _writeCounter++;
@@ -583,9 +614,7 @@ internal static class ShadowWriterPatch
         }
         catch (Exception ex) { AudioBridge.Err($"Audio byte processing error: {ex.Message}"); }
     }
-    
-    private static bool _loggedUnsupported = false;
-    
+
     // Postfix for ReadAuto(Span<byte>, WaveFormat)
     private static void ReadAuto_Span_Postfix(CSCoreAudioOutputDriver __instance, ref int __result)
     {
@@ -601,9 +630,6 @@ internal static class ShadowWriterPatch
         catch (Exception ex) { AudioBridge.Err($"Auto-read processing error: {ex.Message}"); }
     }
     
-    private static bool _loggedByte = false;
-    private static bool _loggedAuto = false;
-    
     // Postfix for base class Start method
     private static void Start_Base_Postfix(AudioOutputDriver __instance, string context)
     {
@@ -617,19 +643,13 @@ internal static class ShadowWriterPatch
             // AudioOutputDriver should have a reference to AudioSystem which has Engine
             try
             {
-                var audioSystemField = AccessTools.Field(typeof(AudioOutputDriver), "System") 
-                    ?? AccessTools.Field(typeof(AudioOutputDriver), "system")
-                    ?? AccessTools.Field(typeof(AudioOutputDriver), "_system");
-                
+                var audioSystemField = AccessTools.Field(typeof(AudioOutputDriver), "AudioSystem");
                 if (audioSystemField != null)
                 {
                     var audioSystem = audioSystemField.GetValue(__instance);
                     if (audioSystem != null)
                     {
-                        var engineField = AccessTools.Field(audioSystem.GetType(), "Engine")
-                            ?? AccessTools.Field(audioSystem.GetType(), "engine")
-                            ?? AccessTools.Field(audioSystem.GetType(), "_engine");
-                        
+                        var engineField = AccessTools.Field(audioSystem.GetType(), "Engine");
                         if (engineField != null)
                         {
                             var engine = engineField.GetValue(audioSystem);
@@ -644,12 +664,6 @@ internal static class ShadowWriterPatch
                                         _capturedSessionId = sessionId.ToString();
                                         if (AudioBridge.IsDebugLogging())
                                             UniLog.Log($"[AudioBridge] Captured Engine SessionID: {_capturedSessionId}");
-
-                                        // If bus is already initialized, update the SessionID
-                                        if (_busInitialized && _capturedSessionId != null)
-                                        {
-                                            ShadowBus.Messenger?.SendString("sessionId", _capturedSessionId); // doesn't do anything
-                                        }
                                     }
                                 }
                             }
@@ -684,11 +698,7 @@ internal static class ShadowWriterPatch
                         
                         // Store reference and apply muting if needed
                         _currentAudioOutput = outp;
-                        //if (AudioBridge.IsEnabled() && AudioBridge.GetCurrentMuteTarget() == MuteTarget.Host)
-                        //{
-                        //    UniLog.Log("[AudioBridge] Applying Host mute configuration on audio start");
-                        //    TryApplyMuteConfiguration(true);
-                        //}
+                        UpdateSessionMuting();
                     }
                 }
             }
@@ -698,29 +708,18 @@ internal static class ShadowWriterPatch
             AudioBridge.Err($"Audio start error: {ex.Message}");
         }
     }
-
-    private static bool _loggedFormat = false;
-    private static int _writeCounter = 0;
     
-    //internal static bool TryApplyMuteConfiguration(bool shouldMute)
-    //{
-    //    if (_currentAudioOutput == null || _currentAudioOutput.Device == null)
-    //    {
-    //        UniLog.Log("[AudioBridge] No audio device available to mute/unmute yet");
-    //        return false;
-    //    }
-        
-    //    ApplyMuteConfiguration(shouldMute);
-    //    return true;
-    //}
-    
-    internal static void TryApplySessionMuting(bool shouldMute)
+    internal static void UpdateSessionMuting()
     {
+        var shouldMute = AudioBridge.ShouldMute();
+        UniLog.Log($"[AudioBridge] Updating session muting. Should mute: {shouldMute}");
+
         try
         {
             if (_currentAudioOutput == null || _currentAudioOutput.Device == null)
             {
                 UniLog.Log("[AudioBridge] No audio device available for session muting (buffer muting will still work)");
+                _isSessionMuted = false;
                 return;
             }
 
@@ -737,7 +736,6 @@ internal static class ShadowWriterPatch
                     sessionFound = true;
                     using var simpleVolume = session.QueryInterface<SimpleAudioVolume>();
                     simpleVolume.MasterVolume = shouldMute ? 0.0f : 1.0f;
-                    _isMuted = shouldMute;
                     if (AudioBridge.IsDebugLogging())
                         UniLog.Log($"[AudioBridge] Host audio session found for PID {currentProcessId}, {(shouldMute ? "muted" : "unmuted")} at session level");
                     
@@ -759,26 +757,30 @@ internal static class ShadowWriterPatch
             
             if (!sessionFound)
             {
-                if (AudioBridge.IsDebugLogging())
-                    UniLog.Log($"[AudioBridge] No audio session found for PID {currentProcessId}, using buffer-level muting only");
+                UniLog.Log($"[AudioBridge] No audio session found for PID {currentProcessId}, using buffer-level muting only");
+                _isSessionMuted = false;
+                return;
             }
+
+            _isSessionMuted = true;
+            return;
         }
         catch (Exception ex)
         {
             AudioBridge.Err($"Session muting failed (buffer muting still active): {ex.Message}");
+            _isSessionMuted = false;
+            return;
         }
     }
     
     internal static void ResetState()
     {
-        UniLog.Log("[AudioBridge] Resetting audio writer state");
-        _busInitialized = false;
-        // Don't reset _currentAudioOutput - keep the reference to the audio device
-        // Don't reset _capturedSessionId - keep it for re-initialization
-        _isMuted = false;
+        UniLog.Log("[AudioBridge] Resetting shadow writer state");
+        _firstRun = true;
         _loggedFormat = false;
         _loggedByte = false;
         _loggedAuto = false;
         _writeCounter = 0;
+        _loggedBufferMuted = false;
     }
 }

--- a/AudioBridge.cs
+++ b/AudioBridge.cs
@@ -26,15 +26,28 @@ public enum MuteTarget
 [BepInDependency(BepInExResoniteShim.PluginMetadata.GUID, BepInDependency.DependencyFlags.HardDependency)]
 public class AudioBridge : BasePlugin
 {
-    private static ConfigEntry<bool>? ENABLED;
-    private static ConfigEntry<MuteTarget>? MUTE_TARGET;
-    private static ConfigEntry<bool>? DEBUG_LOGGING;
+    private static ConfigEntry<bool>? _enabled;
+    private static ConfigEntry<MuteTarget>? _muteTarget;
+    private static ConfigEntry<bool>? _debugLogging;
 
     internal static new ManualLogSource? Log;
 
-    private static MuteTarget _currentMuteTarget = MuteTarget.Host;
-    private static bool _isEnabled = false;
-    private static bool _debugLogging = false;
+    internal static bool ShouldMute => Enabled && MuteTarget == MuteTarget.Host;
+    internal static MuteTarget MuteTarget => _muteTarget!.Value;
+    internal static bool Enabled => _enabled!.Value;
+    internal static bool DebugLogging => _debugLogging!.Value;
+    internal static bool Ready
+    {
+        get
+        {
+            if (Engine.Current?.IsReady != true) return false;
+
+            var renderSystem = Engine.Current.RenderSystem;
+            if (renderSystem is null) return false;
+
+            return Engine.Current.RenderSystem.FrameIndex >= 120;
+        }
+    }
 
     public override void Load()
     {
@@ -42,24 +55,19 @@ public class AudioBridge : BasePlugin
         {
             Log = base.Log;
 
-            ENABLED = Config.Bind("General", "Enabled", true, "Enable audio sharing to renderer process?");
-            MUTE_TARGET = Config.Bind("General", "MuteTarget", MuteTarget.Host, "Which process to mute (prevents double audio)?");
-            DEBUG_LOGGING = Config.Bind("General", "DebugLogging", false, "Enable debug/verbose logging?");
+            _enabled = Config.Bind("General", "Enabled", true, "Enable audio sharing to renderer process?");
+            _muteTarget = Config.Bind("General", "MuteTarget", MuteTarget.Host, "Which process to mute (prevents double audio)?");
+            _debugLogging = Config.Bind("General", "DebugLogging", false, "Enable debug/verbose logging?");
             
             Log.LogInfo("[AudioBridge] Plugin loading!");
             
-            _currentMuteTarget = MUTE_TARGET.Value;
-            _isEnabled = ENABLED.Value;
-            _debugLogging = DEBUG_LOGGING.Value;
-            
             // Subscribe to configuration changes (inline events, crazy concept i know)
-            ENABLED.SettingChanged += (sender, args) => OnEnabledChanged();
-            MUTE_TARGET.SettingChanged += (sender, args) => OnMuteTargetChanged();
-            DEBUG_LOGGING.SettingChanged += (sender, args) => _debugLogging = DEBUG_LOGGING.Value;
+            _enabled.SettingChanged += (sender, args) => OnEnabledChanged();
+            _muteTarget.SettingChanged += (sender, args) => OnMuteTargetChanged();
 
-            Log.LogInfo($"[AudioBridge] On load mute target: {_currentMuteTarget}");
-            Log.LogInfo($"[AudioBridge] On load enabled: {_isEnabled}");
-            Log.LogInfo($"[AudioBridge] On load debug logging: {_isEnabled}");
+            Log.LogInfo($"[AudioBridge] On load mute target: {MuteTarget}");
+            Log.LogInfo($"[AudioBridge] On load enabled: {Enabled}");
+            Log.LogInfo($"[AudioBridge] On load debug logging: {DebugLogging}");
 
             // Time to patch everything manually, yay!
             Log.LogInfo("[AudioBridge] Applying audio driver patches");
@@ -75,7 +83,7 @@ public class AudioBridge : BasePlugin
                 var methods = driverType.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.DeclaredOnly);
                 int patchedCount = 0;
                 
-                if (_debugLogging)
+                if (DebugLogging)
                     Log.LogInfo($"[AudioBridge] Found {methods.Length} audio driver methods");
                 
                 foreach (var method in methods)
@@ -85,7 +93,8 @@ public class AudioBridge : BasePlugin
                     {
                         var parameters = method.GetParameters();
                         var paramInfo = string.Join(", ", parameters.Select(p => $"{p.ParameterType.Name} {p.Name}"));
-                        if (_debugLogging)
+
+                        if (DebugLogging)
                             Log.LogInfo($"[AudioBridge] Discovered audio method: {method.Name}({paramInfo})");
                         
                         // Try to patch each Read method with the appropriate postfix
@@ -119,20 +128,20 @@ public class AudioBridge : BasePlugin
                                     if (postfix != null)
                                     {
                                         harmony.Patch(method, postfix: new HarmonyMethod(postfix));
-                                        if (_debugLogging)
+                                        if (DebugLogging)
                                             Log.LogInfo($"[AudioBridge] Successfully patched {method.Name}");
                                         patchedCount++;
                                     }
                                     else
                                     {
-                                        if (_debugLogging)
+                                        if (DebugLogging)
                                             Log.LogInfo($"[AudioBridge] Patch method {postfixName} not found");
                                     }
                                 }
                             }
                             catch (Exception patchEx)
                             {
-                                if (_debugLogging)
+                                if (DebugLogging)
                                     Log.LogError($"[AudioBridge] Failed to patch {method.Name}: {patchEx.Message}");
                             }
                         }
@@ -141,7 +150,8 @@ public class AudioBridge : BasePlugin
                 
                 // Also check base class methods
                 var baseMethods = baseType.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                if (_debugLogging)
+
+                if (DebugLogging)
                     Log.LogInfo($"[AudioBridge] Base driver has {baseMethods.Length} methods");
                 
                 foreach (var method in baseMethods)
@@ -150,7 +160,8 @@ public class AudioBridge : BasePlugin
                     {
                         var parameters = method.GetParameters();
                         var paramInfo = string.Join(", ", parameters.Select(p => $"{p.ParameterType.Name} {p.Name}"));
-                        if (_debugLogging)
+
+                        if (DebugLogging)
                             Log.LogInfo($"[AudioBridge] Found base method: {method.Name}({paramInfo})");
                         
                         // Patch Start method from base class
@@ -171,7 +182,7 @@ public class AudioBridge : BasePlugin
                     }
                 }
                 
-                if (_debugLogging)
+                if (DebugLogging)
                     Log.LogInfo($"[AudioBridge] Successfully patched {patchedCount} audio methods");
             }
             catch (Exception ex)
@@ -189,55 +200,44 @@ public class AudioBridge : BasePlugin
             Log.LogError($"[AudioBridge] Stack trace: {ex.StackTrace}");
         }
     }
-
-
-    internal static void Msg(string s) => UniLog.Log($"[AudioBridge] {s}");
-    internal static void Err(string s) => UniLog.Error($"[AudioBridge] {s}", stackTrace: false);
     
     private void OnEnabledChanged()
     {
-        var prevEnabled = _isEnabled;
-        _isEnabled = ENABLED!.Value;
+        UniLog.Log($"[AudioBridge] Enabled changed to: {Enabled}");
 
-		UniLog.Log($"[AudioBridge] Enabled changed from {prevEnabled} to {_isEnabled}");
+        if (!Ready) return;
 
-		if (_isEnabled && !prevEnabled)
+        if (Enabled)
         {
-            // Enabling audio sharing
-            UniLog.Log("[AudioBridge] Enabling audio sharing...");
+            if (ShadowBus.Initialized) return;
+
+            UniLog.Log("[AudioBridge] Enabling audio sharing");
             ShadowWriterPatch.ResetState();
         }
-        else if (!_isEnabled && prevEnabled)
+        else if (ShadowBus.Initialized)
         {
-            // Disabling audio sharing
-            UniLog.Log("[AudioBridge] Disabling audio sharing...");
+            UniLog.Log("[AudioBridge] Disabling audio sharing");
 
             ShadowBus.Shutdown();
             ShadowWriterPatch.UpdateSessionMuting();
-
-            UniLog.Log("[AudioBridge] Audio sharing disabled");
         }
     }
     
     private void OnMuteTargetChanged()
     {
-        var previousTarget = _currentMuteTarget;
-        _currentMuteTarget = MUTE_TARGET!.Value;
-        UniLog.Log($"[AudioBridge] Mute target changed from {previousTarget} to {_currentMuteTarget}");
+        UniLog.Log($"[AudioBridge] Mute target changed to {MuteTarget}");
+
+        if (!Ready) return;
         
         // Only process if enabled
-        if (_isEnabled)
+        if (Enabled)
         {
             if (ShadowBus.Initialized)
-                ShadowBus.SendMuteTarget(_currentMuteTarget);
+                ShadowBus.SendMuteTarget(MuteTarget);
+
             ShadowWriterPatch.UpdateSessionMuting();
         }
     }
-    
-    internal static MuteTarget GetCurrentMuteTarget() => _currentMuteTarget;
-    internal static bool IsEnabled() => _isEnabled;
-    internal static bool IsDebugLogging() => _debugLogging;
-    internal static bool ShouldMute() => _isEnabled && _currentMuteTarget == MuteTarget.Host;
 }
 
 internal class ShadowBusFloatsData : IMemoryPackable
@@ -306,7 +306,7 @@ internal static class ShadowBus
 
         _messenger = new Messenger(MESSENGER_NAME, [typeof(ShadowBusInitData), typeof(ShadowBusFloatsData)], []);
 
-        if (AudioBridge.IsDebugLogging())
+        if (AudioBridge.DebugLogging)
             AudioBridge.Log!.LogInfo($"[AudioBridge] Messenger created: {MESSENGER_NAME}");
     }
 
@@ -315,21 +315,21 @@ internal static class ShadowBus
         if (_messenger is null)
             throw new InvalidOperationException("The messenger must be created first!");
 
-		if (Initialized)
-			throw new InvalidOperationException("Already initialized!");
+        if (Initialized)
+            throw new InvalidOperationException("Already initialized!");
 
-		try
+        try
         {
             var initData = new ShadowBusInitData();
             initData.sampleRate = sampleRate;
             initData.channels = channels;
-            initData.muteTarget = (int)AudioBridge.GetCurrentMuteTarget();
+            initData.muteTarget = (int)AudioBridge.MuteTarget;
             initData.sessionId = sessionId;
             _messenger!.SendObject("initData", initData);
 
             Initialized = true;
 
-            if (AudioBridge.IsDebugLogging())
+            if (AudioBridge.DebugLogging)
                 UniLog.Log($"[AudioBridge] Sent init data: {initData.sampleRate}Hz, {initData.channels} channels, muteTarget: {initData.muteTarget}, SessionID: {initData.sessionId ?? "none"}");
 
             return true;
@@ -347,10 +347,10 @@ internal static class ShadowBus
         if (_messenger is null)
             throw new InvalidOperationException("The messenger must be created first!");
 
-		if (!Initialized)
-			throw new InvalidOperationException("Cannot shutdown when not initialized!");
+        if (!Initialized)
+            throw new InvalidOperationException("Cannot shutdown when not initialized!");
 
-		_messenger!.SendEmptyCommand("stop");
+        _messenger!.SendEmptyCommand("stop");
 
         Initialized = false;
     }
@@ -375,10 +375,10 @@ internal static class ShadowBus
         if (_messenger is null)
             throw new InvalidOperationException("The messenger must be created first!");
 
-		if (!Initialized)
-			throw new InvalidOperationException("Cannot send mute target when not initialized!");
+        if (!Initialized)
+            throw new InvalidOperationException("Cannot send mute target when not initialized!");
 
-		_messenger!.SendValue("muteTarget", (int)muteTarget);
+        _messenger!.SendValue("muteTarget", (int)muteTarget);
     }
 }
 
@@ -393,10 +393,11 @@ internal static class ShadowWriterPatch
     private static bool _isSessionMuted = false;
 
     private static bool _firstRun = true;
+    private static bool _initFailed;
 
     private static string? _capturedSessionId = null;
 
-    internal static bool _loggedBufferMuted = false;
+    private static bool _loggedBufferMuted = false;
     private static bool _loggedUnsupported = false;
     private static bool _loggedByte = false;
     private static bool _loggedAuto = false;
@@ -409,7 +410,9 @@ internal static class ShadowWriterPatch
         try
         {
             // Check if audio sharing is enabled
-            if (!AudioBridge.IsEnabled()) return;
+            if (!AudioBridge.Enabled) return;
+            if (_initFailed) return;
+            if (!AudioBridge.Ready) return;
             
             var outp = _fOut(__instance);
             var fmt = outp?.ActualOutputFormat;
@@ -417,7 +420,7 @@ internal static class ShadowWriterPatch
             // Log format info once
             if (!_loggedFormat && fmt != null)
             {
-                if (AudioBridge.IsDebugLogging())
+                if (AudioBridge.DebugLogging)
                     UniLog.Log($"[AudioBridge] Audio output detected: {fmt.SampleRate}Hz, {fmt.Channels}ch, {fmt.BitsPerSample}bit");
                 _loggedFormat = true;
             }
@@ -433,23 +436,20 @@ internal static class ShadowWriterPatch
                 _firstRun = false;
                 if (!ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
                 {
+                    _initFailed = true;
                     return;
                 }
                 ShadowWriterPatch.UpdateSessionMuting();
-            }
-            else if (!ShadowBus.Initialized)
-            {
-                return;
             }
 
             // Write audio data BEFORE muting (so renderer gets unmuted audio)
             ShadowBus.WriteFloats(buffer.AsSpan(offset, floatsRead));
             
             // If host should be muted, zero out the buffer AFTER sharing it
-            if (AudioBridge.ShouldMute())
+            if (AudioBridge.ShouldMute)
             {
                 Array.Clear(buffer, offset, floatsRead);
-                if (!_loggedBufferMuted && AudioBridge.IsDebugLogging())
+                if (!_loggedBufferMuted && AudioBridge.DebugLogging)
                 {
                     _loggedBufferMuted = true;
                     UniLog.Log($"[AudioBridge] Buffer muted");
@@ -458,12 +458,12 @@ internal static class ShadowWriterPatch
             
             // Log periodically
             _writeCounter++;
-            if (_writeCounter % 1000 == 0 && AudioBridge.IsDebugLogging())
+            if (_writeCounter % 1000 == 0 && AudioBridge.DebugLogging)
             {
                 UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks");
             }
         }
-        catch (Exception ex) { AudioBridge.Err($"Audio float processing error: {ex.Message}"); }
+        catch (Exception ex) { UniLog.Error($"Audio float processing error: {ex.Message}"); }
     }
     
     // Postfix for Read(byte[], int, int)
@@ -472,7 +472,9 @@ internal static class ShadowWriterPatch
         try
         {
             // Check if audio sharing is enabled
-            if (!AudioBridge.IsEnabled()) return;
+            if (!AudioBridge.Enabled) return;
+            if (!AudioBridge.Ready) return;
+            if (_initFailed) return;
             if (__result <= 0) return;
             
             var outp = _fOut(__instance);
@@ -483,33 +485,27 @@ internal static class ShadowWriterPatch
             // Log format info once
             if (!_loggedByte)
             {
-                if (AudioBridge.IsDebugLogging())
+                if (AudioBridge.DebugLogging)
                     UniLog.Log($"[AudioBridge] Audio output detected (byte mode): {fmt.SampleRate}Hz, {fmt.Channels}ch, {fmt.BitsPerSample}bit");
                 _loggedByte = true;
             }
             
             // Convert byte data to float based on format
             int bytesRead = __result;
-            int sampleRate = fmt.SampleRate;
-            int channels = fmt.Channels;
             int bitsPerSample = fmt.BitsPerSample;
 
             if (_firstRun)
             {
                 _firstRun = false;
-                if (!ShadowBus.Init(sampleRate: sampleRate, channels: channels, sessionId: _capturedSessionId))
+                if (!ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
                 {
                     return;
                 }
-                ShadowWriterPatch.UpdateSessionMuting();
+                UpdateSessionMuting();
             }
-			else if (!ShadowBus.Initialized)
-			{
-				return;
-			}
 
-			// Convert bytes to float based on bit depth
-			if (bitsPerSample == 32)
+            // Convert bytes to float based on bit depth
+            if (bitsPerSample == 32)
             {
                 // It's already float data in byte form
                 var floatBuffer = new float[bytesRead / sizeof(float)];
@@ -519,10 +515,10 @@ internal static class ShadowWriterPatch
                 ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
-                if (AudioBridge.ShouldMute())
+                if (AudioBridge.ShouldMute)
                 {
                     Array.Clear(buffer, offset, bytesRead);
-                    if (!_loggedBufferMuted && AudioBridge.IsDebugLogging())
+                    if (!_loggedBufferMuted && AudioBridge.DebugLogging)
                     {
                         _loggedBufferMuted = true;
                         UniLog.Log($"[AudioBridge] Buffer muted");
@@ -530,7 +526,7 @@ internal static class ShadowWriterPatch
                 }
                 
                 _writeCounter++;
-                if (_writeCounter % 1000 == 0 && AudioBridge.IsDebugLogging())
+                if (_writeCounter % 1000 == 0 && AudioBridge.DebugLogging)
                 {
                     UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks (32-bit float)");
                 }
@@ -551,10 +547,10 @@ internal static class ShadowWriterPatch
                 ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
-                if (AudioBridge.ShouldMute())
+                if (AudioBridge.ShouldMute)
                 {
                     Array.Clear(buffer, offset, bytesRead);
-                    if (!_loggedBufferMuted && AudioBridge.IsDebugLogging())
+                    if (!_loggedBufferMuted && AudioBridge.DebugLogging)
                     {
                         _loggedBufferMuted = true;
                         UniLog.Log($"[AudioBridge] Buffer muted");
@@ -562,7 +558,7 @@ internal static class ShadowWriterPatch
                 }
                 
                 _writeCounter++;
-                if (_writeCounter % 1000 == 0 && AudioBridge.IsDebugLogging())
+                if (_writeCounter % 1000 == 0 && AudioBridge.DebugLogging)
                 {
                     UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks (16-bit PCM)");
                 }
@@ -586,10 +582,10 @@ internal static class ShadowWriterPatch
                 ShadowBus.WriteFloats(floatBuffer.AsSpan());
                 
                 // If host should be muted, zero out the original buffer AFTER sharing
-                if (AudioBridge.ShouldMute())
+                if (AudioBridge.ShouldMute)
                 {
                     Array.Clear(buffer, offset, bytesRead);
-                    if (!_loggedBufferMuted && AudioBridge.IsDebugLogging())
+                    if (!_loggedBufferMuted && AudioBridge.DebugLogging)
                     {
                         _loggedBufferMuted = true;
                         UniLog.Log($"[AudioBridge] Buffer muted");
@@ -597,7 +593,7 @@ internal static class ShadowWriterPatch
                 }
                 
                 _writeCounter++;
-                if (_writeCounter % 1000 == 0 && AudioBridge.IsDebugLogging())
+                if (_writeCounter % 1000 == 0 && AudioBridge.DebugLogging)
                 {
                     UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks (24-bit PCM)");
                 }
@@ -605,14 +601,14 @@ internal static class ShadowWriterPatch
             else
             {
                 // Unsupported format
-                if (!_loggedUnsupported && AudioBridge.IsDebugLogging())
+                if (!_loggedUnsupported && AudioBridge.DebugLogging)
                 {
                     UniLog.Log($"[AudioBridge] Unsupported audio format: {bitsPerSample}-bit");
                     _loggedUnsupported = true;
                 }
             }
         }
-        catch (Exception ex) { AudioBridge.Err($"Audio byte processing error: {ex.Message}"); }
+        catch (Exception ex) { UniLog.Error($"Audio byte processing error: {ex.Message}"); }
     }
 
     // Postfix for ReadAuto(Span<byte>, WaveFormat)
@@ -621,13 +617,13 @@ internal static class ShadowWriterPatch
         try
         {
             // Log that ReadAuto was called
-            if (!_loggedAuto && AudioBridge.IsDebugLogging())
+            if (!_loggedAuto && AudioBridge.DebugLogging)
             {
                 UniLog.Log("[AudioBridge] Auto-read method detected");
                 _loggedAuto = true;
             }
         }
-        catch (Exception ex) { AudioBridge.Err($"Auto-read processing error: {ex.Message}"); }
+        catch (Exception ex) { UniLog.Error($"Auto-read processing error: {ex.Message}"); }
     }
     
     // Postfix for base class Start method
@@ -636,7 +632,7 @@ internal static class ShadowWriterPatch
         try
         {
             
-            if (AudioBridge.IsDebugLogging())
+            if (AudioBridge.DebugLogging)
                 UniLog.Log($"[AudioBridge] Audio driver started with context: {context}");
             
             // Try to capture the Engine's SessionID through reflection
@@ -662,7 +658,7 @@ internal static class ShadowWriterPatch
                                     if (sessionId != null)
                                     {
                                         _capturedSessionId = sessionId.ToString();
-                                        if (AudioBridge.IsDebugLogging())
+                                        if (AudioBridge.DebugLogging)
                                             UniLog.Log($"[AudioBridge] Captured Engine SessionID: {_capturedSessionId}");
                                     }
                                 }
@@ -673,7 +669,7 @@ internal static class ShadowWriterPatch
             }
             catch (Exception sessionEx)
             {
-                if (AudioBridge.IsDebugLogging())
+                if (AudioBridge.DebugLogging)
                     UniLog.Log($"[AudioBridge] Could not capture SessionID: {sessionEx.Message}");
             }
             
@@ -686,14 +682,14 @@ internal static class ShadowWriterPatch
                     var fmt = outp.ActualOutputFormat;
                     if (fmt != null)
                     {
-                        if (AudioBridge.IsDebugLogging())
+                        if (AudioBridge.DebugLogging)
                             UniLog.Log($"[AudioBridge] Audio device format: {fmt.SampleRate}Hz, {fmt.Channels}ch, {fmt.BitsPerSample}bit");
                     }
                     
                     var device = outp.Device;
                     if (device != null)
                     {
-                        if (AudioBridge.IsDebugLogging())
+                        if (AudioBridge.DebugLogging)
                             UniLog.Log($"[AudioBridge] Audio device: {device.FriendlyName}");
                         
                         // Store reference and apply muting if needed
@@ -705,13 +701,13 @@ internal static class ShadowWriterPatch
         }
         catch (Exception ex)
         {
-            AudioBridge.Err($"Audio start error: {ex.Message}");
+            UniLog.Error($"Audio start error: {ex.Message}");
         }
     }
     
     internal static void UpdateSessionMuting()
     {
-        var shouldMute = AudioBridge.ShouldMute();
+        var shouldMute = AudioBridge.ShouldMute;
         UniLog.Log($"[AudioBridge] Updating session muting. Should mute: {shouldMute}");
 
         try
@@ -736,11 +732,11 @@ internal static class ShadowWriterPatch
                     sessionFound = true;
                     using var simpleVolume = session.QueryInterface<SimpleAudioVolume>();
                     simpleVolume.MasterVolume = shouldMute ? 0.0f : 1.0f;
-                    if (AudioBridge.IsDebugLogging())
+                    if (AudioBridge.DebugLogging)
                         UniLog.Log($"[AudioBridge] Host audio session found for PID {currentProcessId}, {(shouldMute ? "muted" : "unmuted")} at session level");
                     
                     // Also log session details for debugging
-                    if (AudioBridge.IsDebugLogging())
+                    if (AudioBridge.DebugLogging)
                     {
                         try
                         {
@@ -762,12 +758,12 @@ internal static class ShadowWriterPatch
                 return;
             }
 
-            _isSessionMuted = true;
+            _isSessionMuted = shouldMute;
             return;
         }
         catch (Exception ex)
         {
-            AudioBridge.Err($"Session muting failed (buffer muting still active): {ex.Message}");
+            UniLog.Error($"Session muting failed (buffer muting still active): {ex.Message}");
             _isSessionMuted = false;
             return;
         }
@@ -777,6 +773,7 @@ internal static class ShadowWriterPatch
     {
         UniLog.Log("[AudioBridge] Resetting shadow writer state");
         _firstRun = true;
+        _initFailed = false;
         _loggedFormat = false;
         _loggedByte = false;
         _loggedAuto = false;

--- a/AudioBridge.cs
+++ b/AudioBridge.cs
@@ -221,8 +221,11 @@ public class AudioBridge : BasePlugin
         {
             UniLog.Log("[AudioBridge] Disabling audio sharing");
 
-            if (ShadowBus.Initialized)
-                ShadowBus.Shutdown();
+            ShadowBus.RunWithLock(() => 
+            {
+                if (ShadowBus.Initialized)
+                    ShadowBus.Shutdown();
+            });
         }
     }
     
@@ -235,8 +238,11 @@ public class AudioBridge : BasePlugin
         // Only process if enabled
         if (Enabled)
         {
-            if (ShadowBus.Initialized)
-                ShadowBus.SendMuteTarget(MuteTarget);
+            ShadowBus.RunWithLock(() => 
+            {
+                if (ShadowBus.Initialized)
+                    ShadowBus.SendMuteTarget(MuteTarget);
+            });
 
             ShadowWriterPatch.UpdateSessionMuting();
         }
@@ -302,6 +308,8 @@ internal static class ShadowBus
 
     public static bool Initialized { get; private set; } = false;
 
+    private static object _lockObj = new();
+
     public static void CreateMessenger()
     {
         if (_messenger is not null)
@@ -358,6 +366,21 @@ internal static class ShadowBus
         Initialized = false;
     }
 
+    public static void RunWithLock(Action act)
+    {
+        lock (_lockObj)
+        {
+            try
+            {
+                act();
+            }
+            catch (Exception ex)
+            {
+                UniLog.Error($"Exception in ShadowBus RunWithLock!\n{ex}");
+            }
+        }
+    }
+
     public static void WriteFloats(ReadOnlySpan<float> src)
     {
         if (_messenger is null)
@@ -396,7 +419,7 @@ internal static class ShadowWriterPatch
     private static bool _isSessionMuted = false;
 
     private static bool _firstRun = true;
-    private static bool _initFailed;
+    private static bool _initFailed = false;
 
     private static string? _capturedSessionId = null;
 
@@ -407,7 +430,8 @@ internal static class ShadowWriterPatch
     private static bool _loggedFormat = false;
     private static int _writeCounter = 0;
 
-    private static bool _patchesEnabled = true;
+    private static bool? _patchesEnabled = null;
+
     private static DateTime? _shadowBusDisabledTime = null;
 
     private const float DEACTIVATE_TIME_SECONDS = 0.5f;
@@ -417,10 +441,13 @@ internal static class ShadowWriterPatch
     {
         try
         {
-            // Check if audio sharing is enabled
-            if (!_patchesEnabled) return;
-            if (_initFailed) return;
             if (!AudioBridge.Ready) return;
+
+            if (_patchesEnabled is null)
+                _patchesEnabled = AudioBridge.Enabled;
+
+            if (_patchesEnabled != true) return;
+            if (_initFailed) return;
             
             var outp = _fOut(__instance);
             var fmt = outp?.ActualOutputFormat;
@@ -439,49 +466,52 @@ internal static class ShadowWriterPatch
             int floatsRead = Math.Max(0, __result / sizeof(float));
             if (floatsRead == 0) return;
 
-            if (_firstRun)
+            ShadowBus.RunWithLock(() => 
             {
-                _firstRun = false;
-                if (!ShadowBus.Initialized && !ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
+                if (_firstRun)
                 {
-                    _initFailed = true;
-                    return;
-                }
-                ShadowWriterPatch.UpdateSessionMuting();
-            }
-
-            // Write audio data BEFORE muting (so renderer gets unmuted audio)
-            if (ShadowBus.Initialized)
-                ShadowBus.WriteFloats(buffer.AsSpan(offset, floatsRead));
-            
-            // If host should be muted, zero out the buffer AFTER sharing it
-            if (AudioBridge.ShouldMute)
-            {
-                Array.Clear(buffer, offset, floatsRead);
-                if (!_loggedBufferMuted && AudioBridge.DebugLogging)
-                {
-                    _loggedBufferMuted = true;
-                    UniLog.Log($"[AudioBridge] Buffer muted");
-                }
-            }
-            
-            // Log periodically
-            _writeCounter++;
-            if (_writeCounter % 1000 == 0 && AudioBridge.DebugLogging)
-            {
-                UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks");
-            }
-
-            if (!ShadowBus.Initialized)
-            {
-                if (_shadowBusDisabledTime is null)
-                    _shadowBusDisabledTime = DateTime.Now;
-                else if ((DateTime.Now - _shadowBusDisabledTime).Value.TotalSeconds > DEACTIVATE_TIME_SECONDS)
-                {
-                    _patchesEnabled = false;
+                    _firstRun = false;
+                    if (!ShadowBus.Initialized && !ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
+                    {
+                        _initFailed = true;
+                        return;
+                    }
                     ShadowWriterPatch.UpdateSessionMuting();
                 }
-            }
+
+                if (!ShadowBus.Initialized)
+                {
+                    if (_shadowBusDisabledTime is null)
+                        _shadowBusDisabledTime = DateTime.Now;
+                    else if ((DateTime.Now - _shadowBusDisabledTime).Value.TotalSeconds > DEACTIVATE_TIME_SECONDS)
+                    {
+                        _patchesEnabled = false;
+                        ShadowWriterPatch.UpdateSessionMuting();
+                    }
+                    return;
+                }
+
+                // Write audio data BEFORE muting (so renderer gets unmuted audio)
+                ShadowBus.WriteFloats(buffer.AsSpan(offset, floatsRead));
+
+                // If host should be muted, zero out the buffer AFTER sharing it
+                if (AudioBridge.ShouldMute)
+                {
+                    Array.Clear(buffer, offset, floatsRead);
+                    if (!_loggedBufferMuted && AudioBridge.DebugLogging)
+                    {
+                        _loggedBufferMuted = true;
+                        UniLog.Log($"[AudioBridge] Buffer muted");
+                    }
+                }
+
+                // Log periodically
+                _writeCounter++;
+                if (_writeCounter % 1000 == 0 && AudioBridge.DebugLogging)
+                {
+                    UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks");
+                }
+            });
         }
         catch (Exception ex) { UniLog.Error($"Audio float processing error: {ex.Message}"); }
     }
@@ -491,9 +521,12 @@ internal static class ShadowWriterPatch
     {
         try
         {
-            // Check if audio sharing is enabled
-            if (!_patchesEnabled) return;
             if (!AudioBridge.Ready) return;
+
+            if (_patchesEnabled is null)
+                _patchesEnabled = AudioBridge.Enabled;
+
+            if (_patchesEnabled != true) return;
             if (_initFailed) return;
             if (__result <= 0) return;
             
@@ -514,134 +547,104 @@ internal static class ShadowWriterPatch
             int bytesRead = __result;
             int bitsPerSample = fmt.BitsPerSample;
 
-            if (_firstRun)
+            ShadowBus.RunWithLock(() => 
             {
-                _firstRun = false;
-                if (!ShadowBus.Initialized && !ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
+                if (_firstRun)
                 {
-                    _initFailed = true;
+                    _firstRun = false;
+                    if (!ShadowBus.Initialized && !ShadowBus.Init(fmt.SampleRate, fmt.Channels, _capturedSessionId))
+                    {
+                        _initFailed = true;
+                        return;
+                    }
+                    UpdateSessionMuting();
+                }
+
+                if (!ShadowBus.Initialized)
+                {
+                    if (_shadowBusDisabledTime is null)
+                        _shadowBusDisabledTime = DateTime.Now;
+                    else if ((DateTime.Now - _shadowBusDisabledTime).Value.TotalSeconds > DEACTIVATE_TIME_SECONDS)
+                    {
+                        _patchesEnabled = false;
+                        ShadowWriterPatch.UpdateSessionMuting();
+                    }
                     return;
                 }
-                UpdateSessionMuting();
-            }
 
-            // Convert bytes to float based on bit depth
-            if (bitsPerSample == 32)
-            {
-                // It's already float data in byte form
-                var floatBuffer = new float[bytesRead / sizeof(float)];
-                Buffer.BlockCopy(buffer, offset, floatBuffer, 0, bytesRead);
+                bool supported = true;
+                float[]? floatBuffer = null;
 
-                // Write to shared memory BEFORE muting
-                if (ShadowBus.Initialized)
-                    ShadowBus.WriteFloats(floatBuffer.AsSpan());
-                
-                // If host should be muted, zero out the original buffer AFTER sharing
-                if (AudioBridge.ShouldMute)
+                // Convert bytes to float based on bit depth
+                if (bitsPerSample == 32)
                 {
-                    Array.Clear(buffer, offset, bytesRead);
-                    if (!_loggedBufferMuted && AudioBridge.DebugLogging)
+                    // It's already float data in byte form
+                    floatBuffer = new float[bytesRead / sizeof(float)];
+                    Buffer.BlockCopy(buffer, offset, floatBuffer, 0, bytesRead);
+                }
+                else if (bitsPerSample == 16)
+                {
+                    // Convert 16-bit PCM to float
+                    int sampleCount = bytesRead / 2; // 2 bytes per sample
+                    floatBuffer = new float[sampleCount];
+
+                    for (int i = 0; i < sampleCount; i++)
                     {
-                        _loggedBufferMuted = true;
-                        UniLog.Log($"[AudioBridge] Buffer muted");
+                        short sample = BitConverter.ToInt16(buffer, offset + i * 2);
+                        floatBuffer[i] = sample / 32768.0f; // Convert to -1.0 to 1.0 range
                     }
                 }
-                
-                _writeCounter++;
-                if (_writeCounter % 1000 == 0 && AudioBridge.DebugLogging)
+                else if (bitsPerSample == 24)
                 {
-                    UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks (32-bit float)");
-                }
-            }
-            else if (bitsPerSample == 16)
-            {
-                // Convert 16-bit PCM to float
-                int sampleCount = bytesRead / 2; // 2 bytes per sample
-                var floatBuffer = new float[sampleCount];
-                
-                for (int i = 0; i < sampleCount; i++)
-                {
-                    short sample = BitConverter.ToInt16(buffer, offset + i * 2);
-                    floatBuffer[i] = sample / 32768.0f; // Convert to -1.0 to 1.0 range
-                }
-                
-                // Write to shared memory BEFORE muting
-                if (ShadowBus.Initialized)
-                    ShadowBus.WriteFloats(floatBuffer.AsSpan());
-                
-                // If host should be muted, zero out the original buffer AFTER sharing
-                if (AudioBridge.ShouldMute)
-                {
-                    Array.Clear(buffer, offset, bytesRead);
-                    if (!_loggedBufferMuted && AudioBridge.DebugLogging)
+                    // Convert 24-bit PCM to float
+                    int sampleCount = bytesRead / 3; // 3 bytes per sample
+                    floatBuffer = new float[sampleCount];
+
+                    for (int i = 0; i < sampleCount; i++)
                     {
-                        _loggedBufferMuted = true;
-                        UniLog.Log($"[AudioBridge] Buffer muted");
+                        int sample = (buffer[offset + i * 3] << 8) |
+                                     (buffer[offset + i * 3 + 1] << 16) |
+                                     (buffer[offset + i * 3 + 2] << 24);
+                        sample >>= 8; // Sign extend
+                        floatBuffer[i] = sample / 8388608.0f; // Convert to -1.0 to 1.0 range
                     }
                 }
-                
-                _writeCounter++;
-                if (_writeCounter % 1000 == 0 && AudioBridge.DebugLogging)
+                else
                 {
-                    UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks (16-bit PCM)");
-                }
-            }
-            else if (bitsPerSample == 24)
-            {
-                // Convert 24-bit PCM to float
-                int sampleCount = bytesRead / 3; // 3 bytes per sample
-                var floatBuffer = new float[sampleCount];
-                
-                for (int i = 0; i < sampleCount; i++)
-                {
-                    int sample = (buffer[offset + i * 3] << 8) | 
-                                 (buffer[offset + i * 3 + 1] << 16) | 
-                                 (buffer[offset + i * 3 + 2] << 24);
-                    sample >>= 8; // Sign extend
-                    floatBuffer[i] = sample / 8388608.0f; // Convert to -1.0 to 1.0 range
-                }
+                    supported = false;
 
-                // Write to shared memory BEFORE muting
-                if (ShadowBus.Initialized)
-                    ShadowBus.WriteFloats(floatBuffer.AsSpan());
-                
-                // If host should be muted, zero out the original buffer AFTER sharing
-                if (AudioBridge.ShouldMute)
-                {
-                    Array.Clear(buffer, offset, bytesRead);
-                    if (!_loggedBufferMuted && AudioBridge.DebugLogging)
+                    // Unsupported format
+                    if (!_loggedUnsupported && AudioBridge.DebugLogging)
                     {
-                        _loggedBufferMuted = true;
-                        UniLog.Log($"[AudioBridge] Buffer muted");
+                        UniLog.Log($"[AudioBridge] Unsupported audio format: {bitsPerSample}-bit");
+                        _loggedUnsupported = true;
                     }
                 }
-                
-                _writeCounter++;
-                if (_writeCounter % 1000 == 0 && AudioBridge.DebugLogging)
-                {
-                    UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks (24-bit PCM)");
-                }
-            }
-            else
-            {
-                // Unsupported format
-                if (!_loggedUnsupported && AudioBridge.DebugLogging)
-                {
-                    UniLog.Log($"[AudioBridge] Unsupported audio format: {bitsPerSample}-bit");
-                    _loggedUnsupported = true;
-                }
-            }
 
-            if (!ShadowBus.Initialized)
-            {
-                if (_shadowBusDisabledTime is null)
-                    _shadowBusDisabledTime = DateTime.Now;
-                else if ((DateTime.Now - _shadowBusDisabledTime).Value.TotalSeconds > DEACTIVATE_TIME_SECONDS)
+                if (supported)
                 {
-                    _patchesEnabled = false;
-                    ShadowWriterPatch.UpdateSessionMuting();
+                    // Write to shared memory BEFORE muting
+                    if (ShadowBus.Initialized)
+                        ShadowBus.WriteFloats(floatBuffer.AsSpan());
+
+                    // If host should be muted, zero out the original buffer AFTER sharing
+                    if (AudioBridge.ShouldMute)
+                    {
+                        Array.Clear(buffer, offset, bytesRead);
+                        if (!_loggedBufferMuted && AudioBridge.DebugLogging)
+                        {
+                            _loggedBufferMuted = true;
+                            UniLog.Log($"[AudioBridge] Buffer muted");
+                        }
+                    }
+
+                    _writeCounter++;
+                    if (_writeCounter % 1000 == 0 && AudioBridge.DebugLogging)
+                    {
+                        UniLog.Log($"[AudioBridge] Processed {_writeCounter} audio chunks ({bitsPerSample}-bit {(bitsPerSample == 32 ? "float" : "pcm")})");
+                    }
                 }
-            }
+            });
         }
         catch (Exception ex) { UniLog.Error($"Audio byte processing error: {ex.Message}"); }
     }
@@ -811,7 +814,7 @@ internal static class ShadowWriterPatch
 
         _firstRun = true;
         _shadowBusDisabledTime = null;
-        _patchesEnabled = true;
+        _patchesEnabled = null;
         _initFailed = false;
         _loggedFormat = false;
         _loggedByte = false;

--- a/AudioBridge.csproj
+++ b/AudioBridge.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>2.0.0</Version>
-		<Authors>Knackrack615</Authors>
+		<Version>3.0.0</Version>
+		<Authors>Knackrack615, Nytra</Authors>
 		<TargetFramework>net9.0</TargetFramework>
 		<RepositoryUrl>https://github.com/knackrack615/AudioBridge</RepositoryUrl>
 		<PackageId>knackrack615.audiobridge</PackageId>
@@ -24,7 +24,7 @@
 		<GamePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</GamePath>
 		<GamePath Condition="Exists('/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/')">/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/</GamePath>
 		<GamePath Condition="Exists('G:\SteamLibrary\steamapps\common\Resonite\')">G:\SteamLibrary\steamapps\common\Resonite\</GamePath>
-		<PluginTargetDir>$(GamePath)BepInEx\plugins\$(AssemblyName)</PluginTargetDir>
+		<PluginTargetDir>$(GamePath)BepInEx/plugins/$(AssemblyName)</PluginTargetDir>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/AudioBridge.csproj
+++ b/AudioBridge.csproj
@@ -1,76 +1,81 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<Version>2.0.0</Version>
-		<Authors>Knackrack615</Authors>
-		<TargetFramework>net9.0</TargetFramework>
-		<RepositoryUrl>https://github.com/knackrack615/AudioBridge</RepositoryUrl>
-		<PackageId>knackrack615.audiobridge</PackageId>
-		<Product>AudioBridge</Product>
-		<RootNamespace>AudioBridge</RootNamespace>
-		<AssemblyName>AudioBridge</AssemblyName>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<Deterministic>true</Deterministic>
-		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-		<CopyToPlugins>true</CopyToPlugins>
-		<RestoreAdditionalProjectSources>
-			https://nuget-modding.resonite.net/v3/index.json;
-		</RestoreAdditionalProjectSources>
-	</PropertyGroup>
+    <PropertyGroup>
+        <Version>2.0.0</Version>
+        <Authors>Knackrack615</Authors>
+        <TargetFramework>net9.0</TargetFramework>
+        <RepositoryUrl>https://github.com/knackrack615/AudioBridge</RepositoryUrl>
+        <PackageId>knackrack615.audiobridge</PackageId>
+        <Product>AudioBridge</Product>
+        <RootNamespace>AudioBridge</RootNamespace>
+        <AssemblyName>AudioBridge</AssemblyName>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <Deterministic>true</Deterministic>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <CopyToPlugins>true</CopyToPlugins>
+        <RestoreAdditionalProjectSources>
+            https://nuget-modding.resonite.net/v3/index.json;
+        </RestoreAdditionalProjectSources>
+    </PropertyGroup>
 
-	<PropertyGroup>
-		<GamePath Condition="'$(ResonitePath)' != ''">$(ResonitePath)/</GamePath>
-		<GamePath Condition="Exists('$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\')">$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\</GamePath>
-		<GamePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</GamePath>
-		<GamePath Condition="Exists('/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/')">/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/</GamePath>
-		<PluginTargetDir>$(GamePath)BepInEx\plugins\$(AssemblyName)</PluginTargetDir>
-	</PropertyGroup>
+    <PropertyGroup>
+        <GamePath Condition="'$(ResonitePath)' != ''">$(ResonitePath)/</GamePath>
+        <GamePath Condition="Exists('$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\')">$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\</GamePath>
+        <GamePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</GamePath>
+        <GamePath Condition="Exists('/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/')">/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/</GamePath>
+        <GamePath Condition="Exists('G:\SteamLibrary\steamapps\common\Resonite\')">G:\SteamLibrary\steamapps\common\Resonite\</GamePath>
+        <PluginTargetDir>$(GamePath)BepInEx\plugins\$(AssemblyName)</PluginTargetDir>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="BepInEx.NET.CoreCLR" Version="6.0.0-be.*" IncludeAssets="compile" />
-		<PackageReference Include="BepInEx.ResonitePluginInfoProps" Version="3.*" />
-		<PackageReference Include="ResoniteModding.BepInExResoniteShim" Version="0.8.*" />
-	</ItemGroup>
-	
-	<ItemGroup>
-		<Compile Remove="AudioBridgeRenderer.cs" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="BepInEx.NET.CoreCLR" Version="6.0.0-be.*" IncludeAssets="compile" />
+        <PackageReference Include="BepInEx.ResonitePluginInfoProps" Version="3.*" />
+        <PackageReference Include="ResoniteModding.BepInExResoniteShim" Version="0.8.*" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <Compile Remove="AudioBridgeRenderer.cs" />
+    </ItemGroup>
 
-	<ItemGroup Condition="!Exists('$(GamePath)')">
-		<PackageReference Include="Resonite.GameLibs" Version="2025.*" />
-	</ItemGroup>
+    <ItemGroup Condition="!Exists('$(GamePath)')">
+        <PackageReference Include="Resonite.GameLibs" Version="2025.*" />
+    </ItemGroup>
 
-	<ItemGroup Condition="Exists('$(GamePath)')">
-		<Reference Include="FrooxEngine">
-			<HintPath>$(GamePath)FrooxEngine.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Elements.Core">
-			<HintPath>$(GamePath)Elements.Core.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Renderite.Shared">
-			<HintPath>$(GamePath)Renderite.Shared.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="CSCore">
-			<HintPath>$(GamePath)CSCore.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="System.Memory">
-			<HintPath>$(GamePath)\Renderer\Renderite.Renderer_Data\Managed\System.Memory.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-	</ItemGroup>
-	
+    <ItemGroup Condition="Exists('$(GamePath)')">
+        <Reference Include="FrooxEngine">
+            <HintPath>$(GamePath)FrooxEngine.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Elements.Core">
+            <HintPath>$(GamePath)Elements.Core.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Renderite.Shared">
+            <HintPath>$(GamePath)Renderite.Shared.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="CSCore">
+            <HintPath>$(GamePath)CSCore.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="System.Memory">
+            <HintPath>$(GamePath)\Renderer\Renderite.Renderer_Data\Managed\System.Memory.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="InterprocessLib.FrooxEngine">
+            <HintPath>$(GamePath)\BepInEx\plugins\Nytra-InterprocessLib\InterprocessLib.BepisLoader\InterprocessLib.FrooxEngine.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+    </ItemGroup>
+    
 
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<ItemGroup>
-			<PluginFiles Include="$(TargetPath)" />
-			<PluginFiles Include="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
-		</ItemGroup>
-		
-		<Copy SourceFiles="@(PluginFiles)" DestinationFolder="$(PluginTargetDir)" Condition="'$(CopyToPlugins)' == 'true'" />
-		<Message Text="Copied plugin files to $(PluginTargetDir)" Importance="high" Condition="'$(CopyToPlugins)' == 'true'" />
-	</Target>
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+        <ItemGroup>
+            <PluginFiles Include="$(TargetPath)" />
+            <PluginFiles Include="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
+        </ItemGroup>
+        
+        <Copy SourceFiles="@(PluginFiles)" DestinationFolder="$(PluginTargetDir)" Condition="'$(CopyToPlugins)' == 'true'" />
+        <Message Text="Copied plugin files to $(PluginTargetDir)" Importance="high" Condition="'$(CopyToPlugins)' == 'true'" />
+    </Target>
 </Project>

--- a/AudioBridge.csproj
+++ b/AudioBridge.csproj
@@ -30,7 +30,7 @@
 	<ItemGroup>
 		<PackageReference Include="BepInEx.NET.CoreCLR" Version="6.0.0-be.*" IncludeAssets="compile" />
 		<PackageReference Include="BepInEx.ResonitePluginInfoProps" Version="3.*" />
-		<PackageReference Include="ResoniteModding.BepInExResoniteShim" Version="0.8.*" />
+		<PackageReference Include="ResoniteModding.BepInExResoniteShim" Version="0.9.*" />
 	</ItemGroup>
 	
 	<ItemGroup>
@@ -59,11 +59,11 @@
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="System.Memory">
-			<HintPath>$(GamePath)\Renderer\Renderite.Renderer_Data\Managed\System.Memory.dll</HintPath>
+			<HintPath>$(GamePath)Renderer/Renderite.Renderer_Data/Managed/System.Memory.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="InterprocessLib.FrooxEngine">
-			<HintPath>$(GamePath)\BepInEx\plugins\Nytra-InterprocessLib\InterprocessLib.BepisLoader\InterprocessLib.FrooxEngine.dll</HintPath>
+			<HintPath>$(GamePath)BepInEx/plugins/Nytra-InterprocessLib/InterprocessLib.BepisLoader/InterprocessLib.FrooxEngine.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 	</ItemGroup>

--- a/AudioBridge.csproj
+++ b/AudioBridge.csproj
@@ -1,81 +1,81 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <Version>2.0.0</Version>
-        <Authors>Knackrack615</Authors>
-        <TargetFramework>net9.0</TargetFramework>
-        <RepositoryUrl>https://github.com/knackrack615/AudioBridge</RepositoryUrl>
-        <PackageId>knackrack615.audiobridge</PackageId>
-        <Product>AudioBridge</Product>
-        <RootNamespace>AudioBridge</RootNamespace>
-        <AssemblyName>AudioBridge</AssemblyName>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <Deterministic>true</Deterministic>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <CopyToPlugins>true</CopyToPlugins>
-        <RestoreAdditionalProjectSources>
-            https://nuget-modding.resonite.net/v3/index.json;
-        </RestoreAdditionalProjectSources>
-    </PropertyGroup>
+	<PropertyGroup>
+		<Version>2.0.0</Version>
+		<Authors>Knackrack615</Authors>
+		<TargetFramework>net9.0</TargetFramework>
+		<RepositoryUrl>https://github.com/knackrack615/AudioBridge</RepositoryUrl>
+		<PackageId>knackrack615.audiobridge</PackageId>
+		<Product>AudioBridge</Product>
+		<RootNamespace>AudioBridge</RootNamespace>
+		<AssemblyName>AudioBridge</AssemblyName>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<Deterministic>true</Deterministic>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<CopyToPlugins>true</CopyToPlugins>
+		<RestoreAdditionalProjectSources>
+			https://nuget-modding.resonite.net/v3/index.json;
+		</RestoreAdditionalProjectSources>
+	</PropertyGroup>
 
-    <PropertyGroup>
-        <GamePath Condition="'$(ResonitePath)' != ''">$(ResonitePath)/</GamePath>
-        <GamePath Condition="Exists('$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\')">$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\</GamePath>
-        <GamePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</GamePath>
-        <GamePath Condition="Exists('/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/')">/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/</GamePath>
-        <GamePath Condition="Exists('G:\SteamLibrary\steamapps\common\Resonite\')">G:\SteamLibrary\steamapps\common\Resonite\</GamePath>
-        <PluginTargetDir>$(GamePath)BepInEx\plugins\$(AssemblyName)</PluginTargetDir>
-    </PropertyGroup>
+	<PropertyGroup>
+		<GamePath Condition="'$(ResonitePath)' != ''">$(ResonitePath)/</GamePath>
+		<GamePath Condition="Exists('$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\')">$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\</GamePath>
+		<GamePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</GamePath>
+		<GamePath Condition="Exists('/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/')">/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/</GamePath>
+		<GamePath Condition="Exists('G:\SteamLibrary\steamapps\common\Resonite\')">G:\SteamLibrary\steamapps\common\Resonite\</GamePath>
+		<PluginTargetDir>$(GamePath)BepInEx\plugins\$(AssemblyName)</PluginTargetDir>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="BepInEx.NET.CoreCLR" Version="6.0.0-be.*" IncludeAssets="compile" />
-        <PackageReference Include="BepInEx.ResonitePluginInfoProps" Version="3.*" />
-        <PackageReference Include="ResoniteModding.BepInExResoniteShim" Version="0.8.*" />
-    </ItemGroup>
-    
-    <ItemGroup>
-        <Compile Remove="AudioBridgeRenderer.cs" />
-    </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="BepInEx.NET.CoreCLR" Version="6.0.0-be.*" IncludeAssets="compile" />
+		<PackageReference Include="BepInEx.ResonitePluginInfoProps" Version="3.*" />
+		<PackageReference Include="ResoniteModding.BepInExResoniteShim" Version="0.8.*" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<Compile Remove="AudioBridgeRenderer.cs" />
+	</ItemGroup>
 
-    <ItemGroup Condition="!Exists('$(GamePath)')">
-        <PackageReference Include="Resonite.GameLibs" Version="2025.*" />
-    </ItemGroup>
+	<ItemGroup Condition="!Exists('$(GamePath)')">
+		<PackageReference Include="Resonite.GameLibs" Version="2025.*" />
+	</ItemGroup>
 
-    <ItemGroup Condition="Exists('$(GamePath)')">
-        <Reference Include="FrooxEngine">
-            <HintPath>$(GamePath)FrooxEngine.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="Elements.Core">
-            <HintPath>$(GamePath)Elements.Core.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="Renderite.Shared">
-            <HintPath>$(GamePath)Renderite.Shared.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="CSCore">
-            <HintPath>$(GamePath)CSCore.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="System.Memory">
-            <HintPath>$(GamePath)\Renderer\Renderite.Renderer_Data\Managed\System.Memory.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="InterprocessLib.FrooxEngine">
-            <HintPath>$(GamePath)\BepInEx\plugins\Nytra-InterprocessLib\InterprocessLib.BepisLoader\InterprocessLib.FrooxEngine.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-    </ItemGroup>
-    
+	<ItemGroup Condition="Exists('$(GamePath)')">
+		<Reference Include="FrooxEngine">
+			<HintPath>$(GamePath)FrooxEngine.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="Elements.Core">
+			<HintPath>$(GamePath)Elements.Core.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="Renderite.Shared">
+			<HintPath>$(GamePath)Renderite.Shared.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="CSCore">
+			<HintPath>$(GamePath)CSCore.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="System.Memory">
+			<HintPath>$(GamePath)\Renderer\Renderite.Renderer_Data\Managed\System.Memory.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="InterprocessLib.FrooxEngine">
+			<HintPath>$(GamePath)\BepInEx\plugins\Nytra-InterprocessLib\InterprocessLib.BepisLoader\InterprocessLib.FrooxEngine.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+	</ItemGroup>
+	
 
-    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-        <ItemGroup>
-            <PluginFiles Include="$(TargetPath)" />
-            <PluginFiles Include="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
-        </ItemGroup>
-        
-        <Copy SourceFiles="@(PluginFiles)" DestinationFolder="$(PluginTargetDir)" Condition="'$(CopyToPlugins)' == 'true'" />
-        <Message Text="Copied plugin files to $(PluginTargetDir)" Importance="high" Condition="'$(CopyToPlugins)' == 'true'" />
-    </Target>
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		<ItemGroup>
+			<PluginFiles Include="$(TargetPath)" />
+			<PluginFiles Include="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
+		</ItemGroup>
+		
+		<Copy SourceFiles="@(PluginFiles)" DestinationFolder="$(PluginTargetDir)" Condition="'$(CopyToPlugins)' == 'true'" />
+		<Message Text="Copied plugin files to $(PluginTargetDir)" Importance="high" Condition="'$(CopyToPlugins)' == 'true'" />
+	</Target>
 </Project>

--- a/AudioBridgeRenderer.cs
+++ b/AudioBridgeRenderer.cs
@@ -1,15 +1,15 @@
-using System;
 using BepInEx;
-using UnityEngine;
 using CSCore;
 using CSCore.CoreAudioAPI;
 using CSCore.SoundOut;
-using Process = System.Diagnostics.Process;
 using InterprocessLib;
 using Renderite.Shared;
+using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using Process = System.Diagnostics.Process;
 
 namespace AudioBridge.Renderer
 {
@@ -30,25 +30,7 @@ namespace AudioBridge.Renderer
         void Awake()
         {
             Logger.LogInfo("[AudioBridge.Renderer] Initializing audio renderer plugin");
-            
-            try
-            {
-                // Start immediately, no delay
-                InitializeAudio();
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError($"Failed in Awake: {ex}");
-            }
-        }
-        
-        void InitializeAudio()
-        {
-            if (_initialized) return;
-            _initialized = true;
-            
-            Logger.LogInfo("[AudioBridge.Renderer] Starting shared memory audio reader");
-            
+
             try
             {
                 _audioPlayer = new ShadowAudioPlayer();
@@ -72,8 +54,6 @@ namespace AudioBridge.Renderer
         private WasapiOut _audioOut;
         private const string MESSENGER_NAME = "AudioBridge";
         private Messenger _messenger;
-        private MuteTarget _lastMuteTarget;
-        private Task keepAlive;
         private ShadowAudioSource _audioSource;
 
         private int _sampleRate;
@@ -81,13 +61,19 @@ namespace AudioBridge.Renderer
         private MuteTarget _muteTarget;
         private string _sessionId;
 
+        private CancellationTokenSource _cancellation;
+
         private void InitAudio()
         {
-            if (_audioOut is not null) return;
-
+            Debug.Log($"[AudioBridge.Renderer] AUDIO INIT");
             Debug.Log($"[AudioBridge.Renderer] Audio format: {_sampleRate}Hz, {_channels} channels");
             Debug.Log($"[AudioBridge.Renderer] Using SessionID: {_sessionId ?? "none"}");
             Debug.Log($"[AudioBridge.Renderer] Mute target from host: {_muteTarget}");
+
+            if (_audioOut is not null || _audioSource is not null)
+            {
+                throw new InvalidOperationException("Audio output exists!");
+            }
 
             // Create audio source
             _audioSource = new ShadowAudioSource(_sampleRate, _channels);
@@ -112,27 +98,27 @@ namespace AudioBridge.Renderer
 
             Debug.Log("[AudioBridge.Renderer] Audio playback started");
 
-            if (_muteTarget == MuteTarget.Renderer)
-            {
-                // Mute this process's audio session so we don't hear it locally
-                // but it will still be available for recording/streaming
-                MuteCurrentProcessAudio(_audioOut.Device);
-            }
+            UpdateSessionMuting();
 
-            // Keep alive and monitor
-            keepAlive ??= Task.Run(async () =>
+            _cancellation = new();
+
+            //Keep alive and monitor
+            Task.Run(async () =>
             {
                 while (_audioOut is not null)
                 {
                     await Task.Delay(5000);
 
-                    var playbackState = _audioOut?.PlaybackState ?? PlaybackState.Stopped;
-                    if (playbackState == PlaybackState.Stopped && _audioOut is not null)
+                    if (_audioOut is null) break;
+
+                    var playbackState = _audioOut.PlaybackState;
+                    if (playbackState == PlaybackState.Stopped)
                     {
                         Debug.LogWarning("[AudioBridge.Renderer] Audio playback stopped, attempting restart");
                         try
                         {
                             _audioOut.Play();
+                            Debug.Log("[AudioBridge.Renderer] Audio playback restarted");
                         }
                         catch (Exception ex)
                         {
@@ -140,8 +126,7 @@ namespace AudioBridge.Renderer
                         }
                     }
                 }
-                keepAlive = null;
-            });
+            }, _cancellation.Token);
         }
     
         public void Start()
@@ -157,11 +142,7 @@ namespace AudioBridge.Renderer
                 _sampleRate = obj.sampleRate;
                 _channels = obj.channels;
                 _sessionId = obj.sessionId;
-
-                if (obj.muteTarget < 0 || obj.muteTarget > 2)
-                    _muteTarget = MuteTarget.Renderer;
-                else
-                    _muteTarget = (MuteTarget)obj.muteTarget;
+                _muteTarget = (MuteTarget)obj.muteTarget;
 
                 InitAudio();
             });
@@ -169,32 +150,17 @@ namespace AudioBridge.Renderer
             _messenger.ReceiveEmptyCommand("stop", () =>
             {
                 Debug.Log("[AudioBridge.Renderer] Audio sharing disabled by host, stopping playback");
-
-                // Clean up before potentially restarting
-                if (_audioOut != null)
-                {
-                    Debug.Log("[AudioBridge.Renderer] Cleaning up audio output...");
-                    try { _audioOut.Stop(); } catch { }
-                    try { _audioOut.Dispose(); } catch { }
-                    _audioOut = null;
-                }
+                Stop();
             });
 
             _messenger.ReceiveValue<int>("muteTarget", (val) =>
             {
                 var muteTarget = (MuteTarget)val;
-                if (muteTarget != _lastMuteTarget)
+                if (muteTarget != _muteTarget)
                 {
                     Debug.Log($"[AudioBridge.Renderer] Mute target changed to: {muteTarget}");
-                    if (muteTarget == MuteTarget.Renderer)
-                    {
-                        MuteCurrentProcessAudio(_audioOut.Device);
-                    }
-                    else if (_lastMuteTarget == MuteTarget.Renderer)
-                    {
-                        UnmuteCurrentProcessAudio(_audioOut.Device);
-                    }
-                    _lastMuteTarget = muteTarget;
+                    _muteTarget = muteTarget;
+                    UpdateSessionMuting();
                 }
             });
 
@@ -202,18 +168,34 @@ namespace AudioBridge.Renderer
             {
                 _audioSource?.EnqueueFloats(obj.data);
             });
-
-            _messenger.ReceiveString("sessionId", (str) => 
-            { 
-                Debug.Log($"Received sessionId: {str ?? "NULL"}");
-            });
         }
         
         public void Stop()
         {
-            _audioOut?.Stop();
-            _audioOut?.Dispose();
+            _cancellation.Cancel();
+            _cancellation = null;
+            var audioOut = _audioOut;
+            audioOut?.Stop();
+            audioOut?.Dispose();
             _audioOut = null;
+            var audioSource = _audioSource;
+            audioSource?.Dispose();
+            _audioSource = null;
+        }
+
+        private void UpdateSessionMuting()
+        {
+            if (_audioOut?.Device is not null)
+            {
+                if (_muteTarget == MuteTarget.Renderer)
+                {
+                    MuteCurrentProcessAudio(_audioOut.Device);
+                }
+                else
+                {
+                    UnmuteCurrentProcessAudio(_audioOut.Device);
+                }
+            }
         }
         
         private void MuteCurrentProcessAudio(MMDevice device)
@@ -326,7 +308,7 @@ namespace AudioBridge.Renderer
     
     public class ShadowAudioSource : ISampleSource
     {
-        private readonly WaveFormat _format;
+        private WaveFormat _format;
         
         public ShadowAudioSource(int sampleRate, int channels)
         {
@@ -340,17 +322,18 @@ namespace AudioBridge.Renderer
 
         private Queue<float> audioQueue = new();
         private object _lockObj = new();
+        private bool _disposed = false;
 
         public void EnqueueFloats(float[] newData)
         {
             lock (_lockObj)
             {
+                if (_disposed) return;
                 foreach (var flt in newData)
                 {
                     audioQueue.Enqueue(flt);
                 }
             }
-
         }
         
         public int Read(float[] buffer, int offset, int count)
@@ -359,6 +342,12 @@ namespace AudioBridge.Renderer
             {
                 lock (_lockObj)
                 {
+                    if (_disposed)
+                    {
+                        Array.Clear(buffer, offset, count);
+                        return count;
+                    }
+
                     int minSize = Math.Min(count, audioQueue.Count);
 
                     for (int i = offset; i < offset + minSize; i++)
@@ -369,22 +358,32 @@ namespace AudioBridge.Renderer
                     // Fill silence if needed
                     if (minSize < count)
                     {
-                        for (int i = offset + minSize; i < offset + count; i++)
-                        {
-                            buffer[i] = 0f;
-                        }
+                        Array.Clear(buffer, offset + minSize, count - minSize);
+                        //for (int i = offset + minSize; i < offset + count; i++)
+                        //{
+                        //    buffer[i] = 0f;
+                        //}
                     }
                 }
 
                 return count;
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.LogError($"Exception in ShadowAudioSource Read\n{ex}");
                 Array.Clear(buffer, offset, count);
                 return count;
             }
         }
         
-        public void Dispose() { }
+        public void Dispose()
+        {
+            lock (_lockObj)
+            {
+                audioQueue.Clear();
+                audioQueue = null;
+                _disposed = true;
+            }
+        }
     }
 }

--- a/AudioBridgeRenderer.cs
+++ b/AudioBridgeRenderer.cs
@@ -7,6 +7,10 @@ using CSCore;
 using CSCore.CoreAudioAPI;
 using CSCore.SoundOut;
 using Process = System.Diagnostics.Process;
+using InterprocessLib;
+using Renderite.Shared;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace AudioBridge.Renderer
 {
@@ -67,159 +71,106 @@ namespace AudioBridge.Renderer
     public class ShadowAudioPlayer
     {
         private WasapiOut _audioOut;
-        private ShadowBusReader _busReader;
-        private Thread _audioThread;
-        private bool _running;
-        
+        //private ShadowBusReader _busReader;
+        private const string MMF_NAME = "AudioBridge_SharedMemory";
+        //private Thread _audioThread;
+        //private bool _running;
+        private bool _stopped;
+        private Messenger _messenger;
+        private MuteTarget _lastMuteTarget;
+        private Task keepAlive;
+        private ShadowAudioSource _audioSource;
+    
         public void Start()
         {
-            _audioThread = new Thread(AudioThreadMain) { IsBackground = true };
-            _audioThread.Start();
-        }
-        
-        private void AudioThreadMain()
-        {
-            Debug.Log("[AudioBridge.Renderer] Audio thread starting - will monitor for audio sharing");
-            _running = true;
-            bool wasDisabled = false;
-            
-            while (_running)  // Main loop - keeps trying to connect
+            //_audioThread = new Thread(AudioThreadMain) { IsBackground = true };
+            //_audioThread.Start();
+            //AudioThreadMain();
+
+            Debug.Log("[AudioBridge.Renderer] Shadow audio player starting - will monitor for audio sharing");
+
+            // Initialize
+            _messenger = new(MMF_NAME, new List<Type>() { typeof(ShadowBusData) });
+
+            Debug.Log($"[AudioBridge.Renderer] Messenger created: {MMF_NAME}");
+
+            _messenger.ReceiveObject<ShadowBusData>("initData", (obj) =>
             {
-                try
+                if (_stopped) return;
+
+                var sampleRate = obj.sampleRate;
+                var channels = obj.channels;
+                string sessionId = obj.sessionId;
+                Debug.Log($"[AudioBridge.Renderer] Audio format: {sampleRate}Hz, {channels} channels");
+                Debug.Log($"[AudioBridge.Renderer] Using SessionID: {obj.sessionId ?? "none"}");
+
+                // Create audio source
+                _audioSource = new ShadowAudioSource(sampleRate, channels);
+
+                // Initialize audio output with SessionID if available
+                if (!string.IsNullOrEmpty(sessionId) && Guid.TryParse(sessionId, out Guid sessionGuid))
                 {
-                    // Initialize the shadow bus reader
-                    _busReader = new ShadowBusReader();
-                    
-                    // Try to connect to shared memory with better retry logic
-                    bool connected = false;
-                    for (int i = 0; i < 10 && !connected; i++)
-                    {
-                        if (_busReader.TryConnect())
-                        {
-                            connected = true;
-                            break;
-                        }
-                        Thread.Sleep(500);
-                    }
-                    
-                    if (!connected)
-                    {
-                        Debug.Log("[AudioBridge.Renderer] Shared memory not available, will retry...");
-                        _busReader.Dispose();
-                        _busReader = null;
-                        Thread.Sleep(2000);
-                        continue;
-                    }
-                    
-                    // Check if audio sharing is enabled
-                    if (!_busReader.IsEnabled())
-                    {
-                        Debug.Log("[AudioBridge.Renderer] Audio sharing is disabled, waiting for it to be enabled...");
-                        _busReader.Dispose();
-                        _busReader = null;
-                        Thread.Sleep(2000);
-                        continue;
-                    }
-                    
-                    Debug.Log("[AudioBridge.Renderer] Connected and audio sharing is enabled!");
-                    
-                    // Sync with the writer's current position by resetting read index to match write index
-                    _busReader.SyncWithWriter();
-                    
-                    var (sampleRate, channels) = _busReader.GetFormat();
-                    Debug.Log($"[AudioBridge.Renderer] Audio format: {sampleRate}Hz, {channels} channels");
-                    
-                    // Read SessionID from shared memory
-                    string sessionId = _busReader.GetSessionId();
-                    Debug.Log($"[AudioBridge.Renderer] Using SessionID: {sessionId ?? "none"}");
-                    
-                    // Create audio source
-                    var audioSource = new ShadowAudioSource(_busReader, sampleRate, channels);
-                    
-                    // Initialize audio output with SessionID if available
-                    if (!string.IsNullOrEmpty(sessionId) && Guid.TryParse(sessionId, out Guid sessionGuid))
-                    {
-                        // Use the same SessionID but with crossProcessSession: false to maintain separate control
-                        // This groups them in Windows but keeps them as separate audio sessions for muting
-                        _audioOut = new WasapiOut(false, AudioClientShareMode.Shared, 20, sessionGuid, false);
-                        Debug.Log($"[AudioBridge.Renderer] Created WasapiOut with SessionID: {sessionGuid} (crossProcess: false for independent muting)");
-                    }
-                    else
-                    {
-                        // Fallback to default if no SessionID
-                        _audioOut = new WasapiOut(false, AudioClientShareMode.Shared, 20);
-                        Debug.Log("[AudioBridge.Renderer] Created WasapiOut without SessionID (legacy mode)");
-                    }
-                    
-                    _audioOut.Initialize(audioSource.ToWaveSource());
-                    _audioOut.Play();
-                
+                    // Use the same SessionID but with crossProcessSession: false to maintain separate control
+                    // This groups them in Windows but keeps them as separate audio sessions for muting
+                    _audioOut = new WasapiOut(false, AudioClientShareMode.Shared, 20, sessionGuid, false);
+                    Debug.Log($"[AudioBridge.Renderer] Created WasapiOut with SessionID: {sessionGuid} (crossProcess: false for independent muting)");
+                }
+                else
+                {
+                    // Fallback to default if no SessionID
+                    _audioOut = new WasapiOut(false, AudioClientShareMode.Shared, 20);
+                    Debug.Log("[AudioBridge.Renderer] Created WasapiOut without SessionID (legacy mode)");
+                }
+
+                _audioOut.Initialize(_audioSource.ToWaveSource());
+                _audioOut.Play();
+
                 Debug.Log("[AudioBridge.Renderer] Audio playback started");
-                
-                // Check if we should mute based on configuration
-                var muteTarget = _busReader.GetMuteTarget();
+
+                MuteTarget muteTarget;
+                if (obj.muteTarget < 0 || obj.muteTarget > 2) muteTarget = MuteTarget.Renderer;
+                else
+                    muteTarget = (MuteTarget)obj.muteTarget;
+
                 Debug.Log($"[AudioBridge.Renderer] Mute target from host: {muteTarget}");
-                
+
                 if (muteTarget == MuteTarget.Renderer)
                 {
                     // Mute this process's audio session so we don't hear it locally
                     // but it will still be available for recording/streaming
                     MuteCurrentProcessAudio(_audioOut.Device);
                 }
-                _running = true;
+
+                // Keep alive and monitor
+                keepAlive ??= Task.Run(async () =>
+                {
+                    while (!_stopped)
+                    {
+                        await Task.Delay(5000);
+
+                        var playbackState = _audioOut?.PlaybackState ?? PlaybackState.Stopped;
+                        if (playbackState == PlaybackState.Stopped && !_stopped)
+                        {
+                            Debug.LogWarning("[AudioBridge.Renderer] Audio playback stopped, attempting restart");
+                            try
+                            {
+                                _audioOut?.Play();
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.LogError($"[AudioBridge.Renderer] Failed to restart playback: {ex.Message}");
+                            }
+                        }
+                    }
+                });
                 
-                // Keep thread alive and monitor
-                MuteTarget lastMuteTarget = muteTarget;
-                
-                while (_running)
+            });
+
+            _messenger.ReceiveValue<bool>("enabled", (val) =>
+            {
+                if (!val)
                 {
-                    Thread.Sleep(5000);
-                    
-                    // Check if audio sharing has been disabled
-                    if (!_busReader.IsEnabled())
-                    {
-                        Debug.Log("[AudioBridge.Renderer] Audio sharing disabled by host, stopping playback");
-                        wasDisabled = true;
-                        break;  // Break inner loop to clean up, but stay in outer loop to monitor for re-enable
-                    }
-                    
-                    // Check for mute configuration changes
-                    var currentMuteTarget = _busReader.GetMuteTarget();
-                    if (currentMuteTarget != lastMuteTarget)
-                    {
-                        Debug.Log($"[AudioBridge.Renderer] Mute target changed to: {currentMuteTarget}");
-                        if (currentMuteTarget == MuteTarget.Renderer)
-                        {
-                            MuteCurrentProcessAudio(_audioOut.Device);
-                        }
-                        else if (lastMuteTarget == MuteTarget.Renderer)
-                        {
-                            UnmuteCurrentProcessAudio(_audioOut.Device);
-                        }
-                        lastMuteTarget = currentMuteTarget;
-                    }
-                    
-                    var playbackState = _audioOut?.PlaybackState ?? PlaybackState.Stopped;
-                    if (playbackState == PlaybackState.Stopped && _running)
-                    {
-                        Debug.LogWarning("[AudioBridge.Renderer] Audio playback stopped, attempting restart");
-                        try
-                        {
-                            _audioOut?.Play();
-                        }
-                        catch (Exception ex)
-                        {
-                            Debug.LogError($"[AudioBridge.Renderer] Failed to restart playback: {ex.Message}");
-                        }
-                    }
-                }
-                }
-                catch (Exception ex)
-                {
-                    Debug.LogError($"[AudioBridge.Renderer] Audio thread error: {ex}");
-                }
-                finally
-                {
+                    Debug.Log("[AudioBridge.Renderer] Audio sharing disabled by host, stopping playback");
                     // Clean up before potentially restarting
                     if (_audioOut != null)
                     {
@@ -228,42 +179,67 @@ namespace AudioBridge.Renderer
                         try { _audioOut.Dispose(); } catch { }
                         _audioOut = null;
                     }
-                    
-                    if (_busReader != null)
+                }
+            });
+
+            _messenger.ReceiveValue<int>("muteTarget", (val) =>
+            {
+                var muteTarget = (MuteTarget)val;
+                if (muteTarget != _lastMuteTarget)
+                {
+                    Debug.Log($"[AudioBridge.Renderer] Mute target changed to: {muteTarget}");
+                    if (muteTarget == MuteTarget.Renderer)
                     {
-                        try { _busReader.Dispose(); } catch { }
-                        _busReader = null;
+                        MuteCurrentProcessAudio(_audioOut.Device);
                     }
+                    else if (_lastMuteTarget == MuteTarget.Renderer)
+                    {
+                        UnmuteCurrentProcessAudio(_audioOut.Device);
+                    }
+                    _lastMuteTarget = muteTarget;
                 }
-                
-                // Check if we should exit or retry
-                if (!_running) 
-                {
-                    Debug.Log("[AudioBridge.Renderer] Audio thread exiting (Stop() was called)");
-                    break;  // Exit only if Stop() was called
-                }
-                
-                // If audio was disabled, log that we're waiting for re-enable
-                if (wasDisabled)
-                {
-                    Debug.Log("[AudioBridge.Renderer] Audio sharing was disabled, waiting for re-enable...");
-                    wasDisabled = false;
-                }
-                else
-                {
-                    Debug.Log("[AudioBridge.Renderer] Will retry connection in 2 seconds...");
-                }
-                Thread.Sleep(2000);
-            }
+            });
+
+            _messenger.ReceiveValueList<float>("floats", (list) => 
+            {
+                _audioSource?.SetStoredBuffer(list);
+
+            });
+        }
+        
+        private void AudioThreadMain()
+        {
+            
+
+            //// Check if we should exit or retry
+            //if (!_running)
+            //{
+            //	Debug.Log("[AudioBridge.Renderer] Audio thread exiting (Stop() was called)");
+            //	break;  // Exit only if Stop() was called
+            //}
+
+            //// If audio was disabled, log that we're waiting for re-enable
+            //if (wasDisabled)
+            //{
+            //	Debug.Log("[AudioBridge.Renderer] Audio sharing was disabled, waiting for re-enable...");
+            //	wasDisabled = false;
+            //}
+            //else
+            //{
+            //	Debug.Log("[AudioBridge.Renderer] Will retry connection in 2 seconds...");
+            //}
+            //Thread.Sleep(2000);
         }
         
         public void Stop()
         {
-            _running = false;
+            _stopped = true;
             _audioOut?.Stop();
             _audioOut?.Dispose();
-            _busReader?.Dispose();
-            _audioThread?.Join(1000);
+            _audioOut = null; // needed?
+            _messenger = null;
+            //_busReader?.Dispose();
+            //_audioThread?.Join(1000);
         }
         
         private void MuteCurrentProcessAudio(MMDevice device)
@@ -323,175 +299,148 @@ namespace AudioBridge.Renderer
             }
         }
     }
-    
-    public class ShadowBusReader : IDisposable
+
+    internal class ShadowBusData : IMemoryPackable
     {
-        private const string MMF_NAME = "AudioBridge_SharedMemory";
-        private const string MUTEX_NAME = "AudioBridge_SharedMemory_Mutex";
-        private const int HEADER_BYTES = 64;
-        private const int RING_BYTES = 2 * 1024 * 1024; // 2MB ring buffer for stable audio
-        
-        private MemoryMappedFile _mmf;
-        private MemoryMappedViewAccessor _view;
-        private Mutex _mutex;
-        private long _totalSamplesRead;
-        
-        public bool TryConnect()
+        public int sampleRate;
+        public int channels;
+        public int muteTarget;
+        public int enabled;
+        public string sessionId;
+        public void Pack(ref MemoryPacker packer)
         {
-            try
-            {
-                _mmf = MemoryMappedFile.OpenExisting(MMF_NAME, MemoryMappedFileRights.ReadWrite);
-                _mutex = Mutex.OpenExisting(MUTEX_NAME);
-                _view = _mmf.CreateViewAccessor(0, HEADER_BYTES + RING_BYTES, MemoryMappedFileAccess.ReadWrite);
-                return true;
-            }
-            catch
-            {
-                Dispose();
-                return false;
-            }
+            packer.Write(sampleRate);
+            packer.Write(channels);
+            packer.Write(muteTarget);
+            packer.Write(enabled);
+            packer.Write(sessionId);
         }
-        
-        public (int sampleRate, int channels) GetFormat()
+
+        public void Unpack(ref MemoryUnpacker unpacker)
         {
-            if (_mutex == null || _view == null) return (48000, 2);
-            
-            _mutex.WaitOne();
-            try
-            {
-                int sr = _view.ReadInt32(8);
-                int ch = _view.ReadInt32(12);
-                return (sr > 0 ? sr : 48000, ch > 0 ? ch : 2);
-            }
-            finally { _mutex.ReleaseMutex(); }
-        }
-        
-        public string GetSessionId()
-        {
-            if (_mutex == null || _view == null) return null;
-            
-            _mutex.WaitOne();
-            try
-            {
-                byte[] sessionBytes = new byte[36];
-                _view.ReadArray(24, sessionBytes, 0, 36);
-                
-                // Find null terminator
-                int length = Array.IndexOf(sessionBytes, (byte)0);
-                if (length == -1) length = 36;
-                if (length == 0) return null;
-                
-                return System.Text.Encoding.ASCII.GetString(sessionBytes, 0, length);
-            }
-            finally { _mutex.ReleaseMutex(); }
-        }
-        
-        public MuteTarget GetMuteTarget()
-        {
-            if (_mutex == null || _view == null) return MuteTarget.Renderer;
-            
-            _mutex.WaitOne();
-            try
-            {
-                int muteValue = _view.ReadInt32(16);
-                if (muteValue < 0 || muteValue > 2) return MuteTarget.Renderer;
-                return (MuteTarget)muteValue;
-            }
-            finally { _mutex.ReleaseMutex(); }
-        }
-        
-        public bool IsEnabled()
-        {
-            if (_mutex == null || _view == null) return false;
-            
-            _mutex.WaitOne();
-            try
-            {
-                return _view.ReadInt32(20) == 1;
-            }
-            finally { _mutex.ReleaseMutex(); }
-        }
-        
-        public void SyncWithWriter()
-        {
-            if (_mutex == null || _view == null) return;
-            
-            _mutex.WaitOne();
-            try
-            {
-                // Set read index to match write index (start reading from current position)
-                uint w = _view.ReadUInt32(0);
-                _view.Write(4, w);
-                Debug.Log($"[AudioBridge.Renderer] Synced read index to write index: {w}");
-            }
-            finally { _mutex.ReleaseMutex(); }
-        }
-        
-        public int ReadFloats(float[] buffer, int offset, int count)
-        {
-            if (_view == null) return 0;
-            
-            int bytesWanted = count * sizeof(float);
-            byte[] tempBuffer = new byte[bytesWanted];
-            int gotBytes = 0;
-            
-            _mutex.WaitOne();
-            try
-            {
-                uint w = _view.ReadUInt32(0);
-                uint r = _view.ReadUInt32(4);
-                
-                int avail = (int)((RING_BYTES + w - r) % RING_BYTES);
-                if (avail <= 0) return 0;
-                
-                int want = Math.Min(avail, bytesWanted);
-                int headOffset = HEADER_BYTES + (int)r;
-                int tail = Math.Min(want, RING_BYTES - (int)r);
-                
-                // Read first segment
-                _view.ReadArray(headOffset, tempBuffer, 0, tail);
-                
-                // Read wrapped segment if needed
-                if (want > tail)
-                {
-                    int rest = want - tail;
-                    _view.ReadArray(HEADER_BYTES, tempBuffer, tail, rest);
-                }
-                
-                // Update read index
-                r = (uint)((r + want) % RING_BYTES);
-                _view.Write(4, r);
-                gotBytes = want;
-            }
-            finally { _mutex.ReleaseMutex(); }
-            
-            // Convert bytes to floats
-            int floatsRead = gotBytes / sizeof(float);
-            Buffer.BlockCopy(tempBuffer, 0, buffer, offset, gotBytes);
-            
-            _totalSamplesRead += floatsRead;
-            return floatsRead;
-        }
-        
-        public void Dispose()
-        {
-            _view?.Dispose();
-            _mutex?.Dispose();
-            _mmf?.Dispose();
-            _view = null;
-            _mutex = null;
-            _mmf = null;
+            unpacker.Read(ref sampleRate);
+            unpacker.Read(ref channels);
+            unpacker.Read(ref muteTarget);
+            unpacker.Read(ref enabled);
+            unpacker.Read(ref sessionId);
         }
     }
+
+    //public class ShadowBusReader : IDisposable
+ //   {
+ //       private const string MMF_NAME = "AudioBridge_SharedMemory";
+ //       private const string MUTEX_NAME = "AudioBridge_SharedMemory_Mutex";
+ //       private const int HEADER_BYTES = 64;
+ //       private const int RING_BYTES = 2 * 1024 * 1024; // 2MB ring buffer for stable audio
+
+ //       //private MemoryMappedFile _mmf;
+ //       //private MemoryMappedViewAccessor _view;
+ //       //private Mutex _mutex;
+ //       //private MessageProcessingHandler
+ //       internal Messenger _messenger;
+ //       private long _totalSamplesRead;
+        
+ //       public bool TryConnect()
+ //       {
+ //           try
+ //           {
+ //               //_mmf = MemoryMappedFile.OpenExisting(MMF_NAME, MemoryMappedFileRights.ReadWrite);
+ //               //_mutex = Mutex.OpenExisting(MUTEX_NAME);
+ //               //_view = _mmf.CreateViewAccessor(0, HEADER_BYTES + RING_BYTES, MemoryMappedFileAccess.ReadWrite);
+ //               _messenger = new(MMF_NAME, new List<Type>() { typeof(ShadowBusData) });
+ //               return true;
+ //           }
+ //           catch
+ //           {
+ //               Dispose();
+ //               return false;
+ //           }
+ //       }
+        
+ //       //public MuteTarget GetMuteTarget()
+ //       //{
+ //       //    if (_mutex == null || _view == null) return MuteTarget.Renderer;
+            
+ //       //    _mutex.WaitOne();
+ //       //    try
+ //       //    {
+ //       //        int muteValue = _view.ReadInt32(16);
+ //       //        if (muteValue < 0 || muteValue > 2) return MuteTarget.Renderer;
+ //       //        return (MuteTarget)muteValue;
+ //       //    }
+ //       //    finally { _mutex.ReleaseMutex(); }
+ //       //}
+        
+ //       //public bool IsEnabled()
+ //       //{
+ //       //    if (_mutex == null || _view == null) return false;
+            
+ //       //    _mutex.WaitOne();
+ //       //    try
+ //       //    {
+ //       //        return _view.ReadInt32(20) == 1;
+ //       //    }
+ //       //    finally { _mutex.ReleaseMutex(); }
+ //       //}
+        
+ //       public int ReadFloats(float[] buffer, int offset, int count)
+ //       {
+ //           if (_view == null) return 0;
+            
+ //           int bytesWanted = count * sizeof(float);
+ //           byte[] tempBuffer = new byte[bytesWanted];
+ //           int gotBytes = 0;
+            
+ //           _mutex.WaitOne();
+ //           try
+ //           {
+ //               uint w = _view.ReadUInt32(0);
+ //               uint r = _view.ReadUInt32(4);
+                
+ //               int avail = (int)((RING_BYTES + w - r) % RING_BYTES);
+ //               if (avail <= 0) return 0;
+                
+ //               int want = Math.Min(avail, bytesWanted);
+ //               int headOffset = HEADER_BYTES + (int)r;
+ //               int tail = Math.Min(want, RING_BYTES - (int)r);
+                
+ //               // Read first segment
+ //               _view.ReadArray(headOffset, tempBuffer, 0, tail);
+                
+ //               // Read wrapped segment if needed
+ //               if (want > tail)
+ //               {
+ //                   int rest = want - tail;
+ //                   _view.ReadArray(HEADER_BYTES, tempBuffer, tail, rest);
+ //               }
+                
+ //               // Update read index
+ //               r = (uint)((r + want) % RING_BYTES);
+ //               _view.Write(4, r);
+ //               gotBytes = want;
+ //           }
+ //           finally { _mutex.ReleaseMutex(); }
+            
+ //           // Convert bytes to floats
+ //           int floatsRead = gotBytes / sizeof(float);
+ //           Buffer.BlockCopy(tempBuffer, 0, buffer, offset, gotBytes);
+            
+ //           _totalSamplesRead += floatsRead;
+ //           return floatsRead;
+ //       }
+        
+ //       public void Dispose()
+ //       {
+ //           _messenger = null;
+ //       }
+ //   }
     
     public class ShadowAudioSource : ISampleSource
     {
-        private readonly ShadowBusReader _reader;
         private readonly WaveFormat _format;
         
-        public ShadowAudioSource(ShadowBusReader reader, int sampleRate, int channels)
+        public ShadowAudioSource(int sampleRate, int channels)
         {
-            _reader = reader;
             _format = new WaveFormat(sampleRate, 32, channels, AudioEncoding.IeeeFloat);
         }
         
@@ -499,19 +448,44 @@ namespace AudioBridge.Renderer
         public bool CanSeek => false;
         public long Position { get => 0; set { } }
         public long Length => 0;
+
+        private float[] storedBuffer;
+        private object _lockObj = new();
+
+        public void SetStoredBuffer(List<float> newData)
+        {
+            lock (_lockObj)
+                storedBuffer = newData.ToArray();
+        }
         
         public int Read(float[] buffer, int offset, int count)
         {
             try
             {
-                int got = _reader.ReadFloats(buffer, offset, count);
-                
-                // Fill silence if needed
-                if (got < count)
+                while (storedBuffer is null)
                 {
-                    for (int i = offset + got; i < offset + count; i++)
+                    Thread.Sleep(1);
+                }
+                if (storedBuffer == null)
+                {
+                    Array.Clear(buffer, offset, count);
+                }
+                else
+                {
+                    lock (_lockObj)
                     {
-                        buffer[i] = 0f;
+                        Buffer.BlockCopy(storedBuffer, 0, buffer, offset, storedBuffer.Length);
+
+                        // Fill silence if needed
+                        if (storedBuffer.Length < count)
+                        {
+                            for (int i = offset + storedBuffer.Length; i < offset + count; i++)
+                            {
+                                buffer[i] = 0f;
+                            }
+                        }
+
+                        storedBuffer = null;
                     }
                 }
                 

--- a/AudioBridgeRenderer.cs
+++ b/AudioBridgeRenderer.cs
@@ -9,6 +9,7 @@ using InterprocessLib;
 using Renderite.Shared;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace AudioBridge.Renderer
 {
@@ -70,11 +71,78 @@ namespace AudioBridge.Renderer
     {
         private WasapiOut _audioOut;
         private const string MESSENGER_NAME = "AudioBridge";
-        private bool _stopped;
         private Messenger _messenger;
         private MuteTarget _lastMuteTarget;
         private Task keepAlive;
         private ShadowAudioSource _audioSource;
+
+        private int _sampleRate;
+        private int _channels;
+        private MuteTarget _muteTarget;
+        private string _sessionId;
+
+        private void InitAudio()
+        {
+            if (_audioOut is not null) return;
+
+            Debug.Log($"[AudioBridge.Renderer] Audio format: {_sampleRate}Hz, {_channels} channels");
+            Debug.Log($"[AudioBridge.Renderer] Using SessionID: {_sessionId ?? "none"}");
+            Debug.Log($"[AudioBridge.Renderer] Mute target from host: {_muteTarget}");
+
+            // Create audio source
+            _audioSource = new ShadowAudioSource(_sampleRate, _channels);
+
+            // Initialize audio output with SessionID if available
+            if (!string.IsNullOrEmpty(_sessionId) && Guid.TryParse(_sessionId, out Guid sessionGuid))
+            {
+                // Use the same SessionID but with crossProcessSession: false to maintain separate control
+                // This groups them in Windows but keeps them as separate audio sessions for muting
+                _audioOut = new WasapiOut(false, AudioClientShareMode.Shared, 20, sessionGuid, false);
+                Debug.Log($"[AudioBridge.Renderer] Created WasapiOut with SessionID: {sessionGuid} (crossProcess: false for independent muting)");
+            }
+            else
+            {
+                // Fallback to default if no SessionID
+                _audioOut = new WasapiOut(false, AudioClientShareMode.Shared, 20);
+                Debug.Log("[AudioBridge.Renderer] Created WasapiOut without SessionID (legacy mode)");
+            }
+
+            _audioOut.Initialize(_audioSource.ToWaveSource());
+            _audioOut.Play();
+
+            Debug.Log("[AudioBridge.Renderer] Audio playback started");
+
+            if (_muteTarget == MuteTarget.Renderer)
+            {
+                // Mute this process's audio session so we don't hear it locally
+                // but it will still be available for recording/streaming
+                MuteCurrentProcessAudio(_audioOut.Device);
+            }
+
+            // Keep alive and monitor
+            keepAlive ??= Task.Run(async () =>
+            {
+                while (_audioOut is not null)
+                {
+                    await Task.Delay(5000);
+
+                    var playbackState = _audioOut?.PlaybackState ?? PlaybackState.Stopped;
+                    if (playbackState == PlaybackState.Stopped && _audioOut is not null)
+                    {
+                        Debug.LogWarning("[AudioBridge.Renderer] Audio playback stopped, attempting restart");
+                        try
+                        {
+                            _audioOut.Play();
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.LogError($"[AudioBridge.Renderer] Failed to restart playback: {ex.Message}");
+                        }
+                    }
+                }
+                keepAlive = null;
+            });
+        }
     
         public void Start()
         {
@@ -86,89 +154,29 @@ namespace AudioBridge.Renderer
 
             _messenger.ReceiveObject<ShadowBusInitData>("initData", (obj) =>
             {
-                if (_stopped) return;
+                _sampleRate = obj.sampleRate;
+                _channels = obj.channels;
+                _sessionId = obj.sessionId;
 
-                var sampleRate = obj.sampleRate;
-                var channels = obj.channels;
-                string sessionId = obj.sessionId;
-                Debug.Log($"[AudioBridge.Renderer] Audio format: {sampleRate}Hz, {channels} channels");
-                Debug.Log($"[AudioBridge.Renderer] Using SessionID: {sessionId ?? "none"}");
-
-                // Create audio source
-                _audioSource = new ShadowAudioSource(sampleRate, channels);
-
-                // Initialize audio output with SessionID if available
-                if (!string.IsNullOrEmpty(sessionId) && Guid.TryParse(sessionId, out Guid sessionGuid))
-                {
-                    // Use the same SessionID but with crossProcessSession: false to maintain separate control
-                    // This groups them in Windows but keeps them as separate audio sessions for muting
-                    _audioOut = new WasapiOut(false, AudioClientShareMode.Shared, 20, sessionGuid, false);
-                    Debug.Log($"[AudioBridge.Renderer] Created WasapiOut with SessionID: {sessionGuid} (crossProcess: false for independent muting)");
-                }
+                if (obj.muteTarget < 0 || obj.muteTarget > 2)
+                    _muteTarget = MuteTarget.Renderer;
                 else
-                {
-                    // Fallback to default if no SessionID
-                    _audioOut = new WasapiOut(false, AudioClientShareMode.Shared, 20);
-                    Debug.Log("[AudioBridge.Renderer] Created WasapiOut without SessionID (legacy mode)");
-                }
+                    _muteTarget = (MuteTarget)obj.muteTarget;
 
-                _audioOut.Initialize(_audioSource.ToWaveSource());
-                _audioOut.Play();
-
-                Debug.Log("[AudioBridge.Renderer] Audio playback started");
-
-                MuteTarget muteTarget;
-                if (obj.muteTarget < 0 || obj.muteTarget > 2) muteTarget = MuteTarget.Renderer;
-                else
-                    muteTarget = (MuteTarget)obj.muteTarget;
-
-                Debug.Log($"[AudioBridge.Renderer] Mute target from host: {muteTarget}");
-
-                if (muteTarget == MuteTarget.Renderer)
-                {
-                    // Mute this process's audio session so we don't hear it locally
-                    // but it will still be available for recording/streaming
-                    MuteCurrentProcessAudio(_audioOut.Device);
-                }
-
-                // Keep alive and monitor
-                keepAlive ??= Task.Run(async () =>
-                {
-                    while (!_stopped)
-                    {
-                        await Task.Delay(5000);
-
-                        var playbackState = _audioOut?.PlaybackState ?? PlaybackState.Stopped;
-                        if (playbackState == PlaybackState.Stopped && !_stopped)
-                        {
-                            Debug.LogWarning("[AudioBridge.Renderer] Audio playback stopped, attempting restart");
-                            try
-                            {
-                                _audioOut?.Play();
-                            }
-                            catch (Exception ex)
-                            {
-                                Debug.LogError($"[AudioBridge.Renderer] Failed to restart playback: {ex.Message}");
-                            }
-                        }
-                    }
-                });
-                
+                InitAudio();
             });
 
-            _messenger.ReceiveValue<bool>("enabled", (val) =>
+            _messenger.ReceiveEmptyCommand("stop", () =>
             {
-                if (!val)
+                Debug.Log("[AudioBridge.Renderer] Audio sharing disabled by host, stopping playback");
+
+                // Clean up before potentially restarting
+                if (_audioOut != null)
                 {
-                    Debug.Log("[AudioBridge.Renderer] Audio sharing disabled by host, stopping playback");
-                    // Clean up before potentially restarting
-                    if (_audioOut != null)
-                    {
-                        Debug.Log("[AudioBridge.Renderer] Cleaning up audio output...");
-                        try { _audioOut.Stop(); } catch { }
-                        try { _audioOut.Dispose(); } catch { }
-                        _audioOut = null;
-                    }
+                    Debug.Log("[AudioBridge.Renderer] Cleaning up audio output...");
+                    try { _audioOut.Stop(); } catch { }
+                    try { _audioOut.Dispose(); } catch { }
+                    _audioOut = null;
                 }
             });
 
@@ -194,15 +202,18 @@ namespace AudioBridge.Renderer
             {
                 _audioSource?.EnqueueFloats(obj.data);
             });
+
+            _messenger.ReceiveString("sessionId", (str) => 
+            { 
+                Debug.Log($"Received sessionId: {str ?? "NULL"}");
+            });
         }
         
         public void Stop()
         {
-            _stopped = true;
             _audioOut?.Stop();
             _audioOut?.Dispose();
-            _audioOut = null; // needed?
-            _messenger = null;
+            _audioOut = null;
         }
         
         private void MuteCurrentProcessAudio(MMDevice device)
@@ -295,14 +306,12 @@ namespace AudioBridge.Renderer
         public int sampleRate;
         public int channels;
         public int muteTarget;
-        public int enabled;
         public string sessionId;
         public void Pack(ref MemoryPacker packer)
         {
             packer.Write(sampleRate);
             packer.Write(channels);
             packer.Write(muteTarget);
-            packer.Write(enabled);
             packer.Write(sessionId);
         }
 
@@ -311,7 +320,6 @@ namespace AudioBridge.Renderer
             unpacker.Read(ref sampleRate);
             unpacker.Read(ref channels);
             unpacker.Read(ref muteTarget);
-            unpacker.Read(ref enabled);
             unpacker.Read(ref sessionId);
         }
     }

--- a/AudioBridgeRenderer.cs
+++ b/AudioBridgeRenderer.cs
@@ -23,7 +23,7 @@ namespace AudioBridge.Renderer
     }
     
     [BepInPlugin("com.knackrack615.AudioBridgeRenderer", "AudioBridge Renderer", "1.0.0")]
-    public class AudioBridgeRendererPlugin : BaseUnityPlugin
+	public class AudioBridgeRendererPlugin : BaseUnityPlugin
     {
         private ShadowAudioPlayer _audioPlayer;
         private bool _initialized = false;
@@ -71,10 +71,7 @@ namespace AudioBridge.Renderer
     public class ShadowAudioPlayer
     {
         private WasapiOut _audioOut;
-        //private ShadowBusReader _busReader;
-        private const string MMF_NAME = "AudioBridge_SharedMemory";
-        //private Thread _audioThread;
-        //private bool _running;
+        private const string MESSENGER_NAME = "AudioBridge";
         private bool _stopped;
         private Messenger _messenger;
         private MuteTarget _lastMuteTarget;
@@ -83,18 +80,13 @@ namespace AudioBridge.Renderer
     
         public void Start()
         {
-            //_audioThread = new Thread(AudioThreadMain) { IsBackground = true };
-            //_audioThread.Start();
-            //AudioThreadMain();
-
             Debug.Log("[AudioBridge.Renderer] Shadow audio player starting - will monitor for audio sharing");
 
-            // Initialize
-            _messenger = new(MMF_NAME, new List<Type>() { typeof(ShadowBusData) });
+            _messenger = new(MESSENGER_NAME, new List<Type>() { typeof(ShadowBusInitData), typeof(ShadowBusFloatsData) });
 
-            Debug.Log($"[AudioBridge.Renderer] Messenger created: {MMF_NAME}");
+            Debug.Log($"[AudioBridge.Renderer] Messenger created: {MESSENGER_NAME}");
 
-            _messenger.ReceiveObject<ShadowBusData>("initData", (obj) =>
+            _messenger.ReceiveObject<ShadowBusInitData>("initData", (obj) =>
             {
                 if (_stopped) return;
 
@@ -102,7 +94,7 @@ namespace AudioBridge.Renderer
                 var channels = obj.channels;
                 string sessionId = obj.sessionId;
                 Debug.Log($"[AudioBridge.Renderer] Audio format: {sampleRate}Hz, {channels} channels");
-                Debug.Log($"[AudioBridge.Renderer] Using SessionID: {obj.sessionId ?? "none"}");
+                Debug.Log($"[AudioBridge.Renderer] Using SessionID: {sessionId ?? "none"}");
 
                 // Create audio source
                 _audioSource = new ShadowAudioSource(sampleRate, channels);
@@ -200,35 +192,10 @@ namespace AudioBridge.Renderer
                 }
             });
 
-            _messenger.ReceiveValueList<float>("floats", (list) => 
+            _messenger.ReceiveObject<ShadowBusFloatsData>("floats", (obj) => 
             {
-                _audioSource?.SetStoredBuffer(list);
-
+                _audioSource?.EnqueueFloats(obj.data);
             });
-        }
-        
-        private void AudioThreadMain()
-        {
-            
-
-            //// Check if we should exit or retry
-            //if (!_running)
-            //{
-            //	Debug.Log("[AudioBridge.Renderer] Audio thread exiting (Stop() was called)");
-            //	break;  // Exit only if Stop() was called
-            //}
-
-            //// If audio was disabled, log that we're waiting for re-enable
-            //if (wasDisabled)
-            //{
-            //	Debug.Log("[AudioBridge.Renderer] Audio sharing was disabled, waiting for re-enable...");
-            //	wasDisabled = false;
-            //}
-            //else
-            //{
-            //	Debug.Log("[AudioBridge.Renderer] Will retry connection in 2 seconds...");
-            //}
-            //Thread.Sleep(2000);
         }
         
         public void Stop()
@@ -238,8 +205,6 @@ namespace AudioBridge.Renderer
             _audioOut?.Dispose();
             _audioOut = null; // needed?
             _messenger = null;
-            //_busReader?.Dispose();
-            //_audioThread?.Join(1000);
         }
         
         private void MuteCurrentProcessAudio(MMDevice device)
@@ -300,7 +265,34 @@ namespace AudioBridge.Renderer
         }
     }
 
-    internal class ShadowBusData : IMemoryPackable
+	internal class ShadowBusFloatsData : IMemoryPackable
+	{
+		public float[] data;
+
+		public void Pack(ref MemoryPacker packer)
+		{
+			packer.Write(data.Length);
+			foreach (var flt in data)
+			{
+				packer.Write(flt);
+			}
+		}
+
+		public void Unpack(ref MemoryUnpacker unpacker)
+		{
+			int len = 0;
+			unpacker.Read(ref len);
+			data = new float[len];
+			for (int i = 0; i < len; i++)
+			{
+				float flt = 0f;
+				unpacker.Read(ref flt);
+				data[i] = flt;
+			}
+		}
+	}
+
+	internal class ShadowBusInitData : IMemoryPackable
     {
         public int sampleRate;
         public int channels;
@@ -325,115 +317,6 @@ namespace AudioBridge.Renderer
             unpacker.Read(ref sessionId);
         }
     }
-
-    //public class ShadowBusReader : IDisposable
- //   {
- //       private const string MMF_NAME = "AudioBridge_SharedMemory";
- //       private const string MUTEX_NAME = "AudioBridge_SharedMemory_Mutex";
- //       private const int HEADER_BYTES = 64;
- //       private const int RING_BYTES = 2 * 1024 * 1024; // 2MB ring buffer for stable audio
-
- //       //private MemoryMappedFile _mmf;
- //       //private MemoryMappedViewAccessor _view;
- //       //private Mutex _mutex;
- //       //private MessageProcessingHandler
- //       internal Messenger _messenger;
- //       private long _totalSamplesRead;
-        
- //       public bool TryConnect()
- //       {
- //           try
- //           {
- //               //_mmf = MemoryMappedFile.OpenExisting(MMF_NAME, MemoryMappedFileRights.ReadWrite);
- //               //_mutex = Mutex.OpenExisting(MUTEX_NAME);
- //               //_view = _mmf.CreateViewAccessor(0, HEADER_BYTES + RING_BYTES, MemoryMappedFileAccess.ReadWrite);
- //               _messenger = new(MMF_NAME, new List<Type>() { typeof(ShadowBusData) });
- //               return true;
- //           }
- //           catch
- //           {
- //               Dispose();
- //               return false;
- //           }
- //       }
-        
- //       //public MuteTarget GetMuteTarget()
- //       //{
- //       //    if (_mutex == null || _view == null) return MuteTarget.Renderer;
-            
- //       //    _mutex.WaitOne();
- //       //    try
- //       //    {
- //       //        int muteValue = _view.ReadInt32(16);
- //       //        if (muteValue < 0 || muteValue > 2) return MuteTarget.Renderer;
- //       //        return (MuteTarget)muteValue;
- //       //    }
- //       //    finally { _mutex.ReleaseMutex(); }
- //       //}
-        
- //       //public bool IsEnabled()
- //       //{
- //       //    if (_mutex == null || _view == null) return false;
-            
- //       //    _mutex.WaitOne();
- //       //    try
- //       //    {
- //       //        return _view.ReadInt32(20) == 1;
- //       //    }
- //       //    finally { _mutex.ReleaseMutex(); }
- //       //}
-        
- //       public int ReadFloats(float[] buffer, int offset, int count)
- //       {
- //           if (_view == null) return 0;
-            
- //           int bytesWanted = count * sizeof(float);
- //           byte[] tempBuffer = new byte[bytesWanted];
- //           int gotBytes = 0;
-            
- //           _mutex.WaitOne();
- //           try
- //           {
- //               uint w = _view.ReadUInt32(0);
- //               uint r = _view.ReadUInt32(4);
-                
- //               int avail = (int)((RING_BYTES + w - r) % RING_BYTES);
- //               if (avail <= 0) return 0;
-                
- //               int want = Math.Min(avail, bytesWanted);
- //               int headOffset = HEADER_BYTES + (int)r;
- //               int tail = Math.Min(want, RING_BYTES - (int)r);
-                
- //               // Read first segment
- //               _view.ReadArray(headOffset, tempBuffer, 0, tail);
-                
- //               // Read wrapped segment if needed
- //               if (want > tail)
- //               {
- //                   int rest = want - tail;
- //                   _view.ReadArray(HEADER_BYTES, tempBuffer, tail, rest);
- //               }
-                
- //               // Update read index
- //               r = (uint)((r + want) % RING_BYTES);
- //               _view.Write(4, r);
- //               gotBytes = want;
- //           }
- //           finally { _mutex.ReleaseMutex(); }
-            
- //           // Convert bytes to floats
- //           int floatsRead = gotBytes / sizeof(float);
- //           Buffer.BlockCopy(tempBuffer, 0, buffer, offset, gotBytes);
-            
- //           _totalSamplesRead += floatsRead;
- //           return floatsRead;
- //       }
-        
- //       public void Dispose()
- //       {
- //           _messenger = null;
- //       }
- //   }
     
     public class ShadowAudioSource : ISampleSource
     {
@@ -449,47 +332,45 @@ namespace AudioBridge.Renderer
         public long Position { get => 0; set { } }
         public long Length => 0;
 
-        private float[] storedBuffer;
+        private Queue<float> audioQueue = new();
         private object _lockObj = new();
 
-        public void SetStoredBuffer(List<float> newData)
+        public void EnqueueFloats(float[] newData)
         {
             lock (_lockObj)
-                storedBuffer = newData.ToArray();
-        }
+            {
+                foreach (var flt in newData)
+                {
+                    audioQueue.Enqueue(flt);
+                }
+			}
+
+		}
         
         public int Read(float[] buffer, int offset, int count)
         {
             try
             {
-                while (storedBuffer is null)
-                {
-                    Thread.Sleep(1);
-                }
-                if (storedBuffer == null)
-                {
-                    Array.Clear(buffer, offset, count);
-                }
-                else
-                {
-                    lock (_lockObj)
+				lock (_lockObj)
+				{
+                    int minSize = Math.Min(count, audioQueue.Count);
+
+					for (int i = offset; i < offset + minSize; i++)
                     {
-                        Buffer.BlockCopy(storedBuffer, 0, buffer, offset, storedBuffer.Length);
-
-                        // Fill silence if needed
-                        if (storedBuffer.Length < count)
-                        {
-                            for (int i = offset + storedBuffer.Length; i < offset + count; i++)
-                            {
-                                buffer[i] = 0f;
-                            }
-                        }
-
-                        storedBuffer = null;
+                        buffer[i] = audioQueue.Dequeue();
                     }
-                }
-                
-                return count;
+
+					// Fill silence if needed
+					if (minSize < count)
+					{
+						for (int i = offset + minSize; i < offset + count; i++)
+						{
+							buffer[i] = 0f;
+						}
+					}
+				}
+
+				return count;
             }
             catch
             {

--- a/AudioBridgeRenderer.cs
+++ b/AudioBridgeRenderer.cs
@@ -6,6 +6,7 @@ using InterprocessLib;
 using Renderite.Shared;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -25,7 +26,6 @@ namespace AudioBridge.Renderer
     public class AudioBridgeRendererPlugin : BaseUnityPlugin
     {
         private ShadowAudioPlayer _audioPlayer;
-        private bool _initialized = false;
         
         void Awake()
         {
@@ -61,7 +61,10 @@ namespace AudioBridge.Renderer
         private MuteTarget _muteTarget;
         private string _sessionId;
 
-        private CancellationTokenSource _cancellation;
+        private bool _startedInitTask;
+        private bool _stopped = true;
+
+        private Task _keepAlive;
 
         private void InitAudio()
         {
@@ -96,14 +99,14 @@ namespace AudioBridge.Renderer
             _audioOut.Initialize(_audioSource.ToWaveSource());
             _audioOut.Play();
 
+            _stopped = false;
+
             Debug.Log("[AudioBridge.Renderer] Audio playback started");
 
             UpdateSessionMuting();
 
-            _cancellation = new();
-
             //Keep alive and monitor
-            Task.Run(async () =>
+            _keepAlive ??= Task.Run(async () =>
             {
                 while (_audioOut is not null)
                 {
@@ -126,7 +129,8 @@ namespace AudioBridge.Renderer
                         }
                     }
                 }
-            }, _cancellation.Token);
+                _keepAlive = null;
+            });
         }
     
         public void Start()
@@ -144,7 +148,26 @@ namespace AudioBridge.Renderer
                 _sessionId = obj.sessionId;
                 _muteTarget = (MuteTarget)obj.muteTarget;
 
-                InitAudio();
+                if (!_stopped)
+                {
+                    if (!_startedInitTask)
+                    {
+                        Task.Run(async () =>
+                        {
+                            while (!_stopped)
+                            {
+                                await Task.Delay(1);
+                            }
+                            InitAudio();
+                            _startedInitTask = false;
+                        });
+                        _startedInitTask = true;
+                    }
+                }
+                else
+                {
+                    InitAudio();
+                }
             });
 
             _messenger.ReceiveEmptyCommand("stop", () =>
@@ -156,31 +179,25 @@ namespace AudioBridge.Renderer
             _messenger.ReceiveValue<int>("muteTarget", (val) =>
             {
                 var muteTarget = (MuteTarget)val;
-                if (muteTarget != _muteTarget)
-                {
-                    Debug.Log($"[AudioBridge.Renderer] Mute target changed to: {muteTarget}");
-                    _muteTarget = muteTarget;
-                    UpdateSessionMuting();
-                }
+                Debug.Log($"[AudioBridge.Renderer] Mute target changed to: {muteTarget}");
+                _muteTarget = muteTarget;
+                UpdateSessionMuting();
             });
 
             _messenger.ReceiveObject<ShadowBusFloatsData>("floats", (obj) => 
             {
-                _audioSource?.EnqueueFloats(obj.data);
+                _audioSource.EnqueueFloats(obj.data);
             });
         }
         
         public void Stop()
         {
-            _cancellation.Cancel();
-            _cancellation = null;
-            var audioOut = _audioOut;
-            audioOut?.Stop();
-            audioOut?.Dispose();
+            _audioOut?.Stop();
+            _audioOut?.Dispose();
             _audioOut = null;
-            var audioSource = _audioSource;
-            audioSource?.Dispose();
+            _audioSource?.Dispose();
             _audioSource = null;
+            _stopped = true;
         }
 
         private void UpdateSessionMuting()
@@ -308,7 +325,7 @@ namespace AudioBridge.Renderer
     
     public class ShadowAudioSource : ISampleSource
     {
-        private WaveFormat _format;
+        private readonly WaveFormat _format;
         
         public ShadowAudioSource(int sampleRate, int channels)
         {
@@ -359,14 +376,10 @@ namespace AudioBridge.Renderer
                     if (minSize < count)
                     {
                         Array.Clear(buffer, offset + minSize, count - minSize);
-                        //for (int i = offset + minSize; i < offset + count; i++)
-                        //{
-                        //    buffer[i] = 0f;
-                        //}
                     }
-                }
 
-                return count;
+                    return count;
+                }
             }
             catch (Exception ex)
             {
@@ -378,6 +391,7 @@ namespace AudioBridge.Renderer
         
         public void Dispose()
         {
+            Debug.Log("[AudioBridge.Renderer] Disposing ShadowAudioSource...");
             lock (_lockObj)
             {
                 audioQueue.Clear();

--- a/AudioBridgeRenderer.cs
+++ b/AudioBridgeRenderer.cs
@@ -6,8 +6,6 @@ using InterprocessLib;
 using Renderite.Shared;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 using Process = System.Diagnostics.Process;
@@ -22,7 +20,7 @@ namespace AudioBridge.Renderer
         Renderer = 2
     }
     
-    [BepInPlugin("com.knackrack615.AudioBridgeRenderer", "AudioBridge Renderer", "1.0.0")]
+    [BepInPlugin("com.knackrack615.AudioBridgeRenderer", "AudioBridge Renderer", "3.0.0")]
     public class AudioBridgeRendererPlugin : BaseUnityPlugin
     {
         private ShadowAudioPlayer _audioPlayer;

--- a/AudioBridgeRenderer.cs
+++ b/AudioBridgeRenderer.cs
@@ -1,6 +1,4 @@
 using System;
-using System.IO.MemoryMappedFiles;
-using System.Threading;
 using BepInEx;
 using UnityEngine;
 using CSCore;

--- a/AudioBridgeRenderer.cs
+++ b/AudioBridgeRenderer.cs
@@ -23,7 +23,7 @@ namespace AudioBridge.Renderer
     }
     
     [BepInPlugin("com.knackrack615.AudioBridgeRenderer", "AudioBridge Renderer", "1.0.0")]
-	public class AudioBridgeRendererPlugin : BaseUnityPlugin
+    public class AudioBridgeRendererPlugin : BaseUnityPlugin
     {
         private ShadowAudioPlayer _audioPlayer;
         private bool _initialized = false;
@@ -265,34 +265,34 @@ namespace AudioBridge.Renderer
         }
     }
 
-	internal class ShadowBusFloatsData : IMemoryPackable
-	{
-		public float[] data;
+    internal class ShadowBusFloatsData : IMemoryPackable
+    {
+        public float[] data;
 
-		public void Pack(ref MemoryPacker packer)
-		{
-			packer.Write(data.Length);
-			foreach (var flt in data)
-			{
-				packer.Write(flt);
-			}
-		}
+        public void Pack(ref MemoryPacker packer)
+        {
+            packer.Write(data.Length);
+            foreach (var flt in data)
+            {
+                packer.Write(flt);
+            }
+        }
 
-		public void Unpack(ref MemoryUnpacker unpacker)
-		{
-			int len = 0;
-			unpacker.Read(ref len);
-			data = new float[len];
-			for (int i = 0; i < len; i++)
-			{
-				float flt = 0f;
-				unpacker.Read(ref flt);
-				data[i] = flt;
-			}
-		}
-	}
+        public void Unpack(ref MemoryUnpacker unpacker)
+        {
+            int len = 0;
+            unpacker.Read(ref len);
+            data = new float[len];
+            for (int i = 0; i < len; i++)
+            {
+                float flt = 0f;
+                unpacker.Read(ref flt);
+                data[i] = flt;
+            }
+        }
+    }
 
-	internal class ShadowBusInitData : IMemoryPackable
+    internal class ShadowBusInitData : IMemoryPackable
     {
         public int sampleRate;
         public int channels;
@@ -343,34 +343,34 @@ namespace AudioBridge.Renderer
                 {
                     audioQueue.Enqueue(flt);
                 }
-			}
+            }
 
-		}
+        }
         
         public int Read(float[] buffer, int offset, int count)
         {
             try
             {
-				lock (_lockObj)
-				{
+                lock (_lockObj)
+                {
                     int minSize = Math.Min(count, audioQueue.Count);
 
-					for (int i = offset; i < offset + minSize; i++)
+                    for (int i = offset; i < offset + minSize; i++)
                     {
                         buffer[i] = audioQueue.Dequeue();
                     }
 
-					// Fill silence if needed
-					if (minSize < count)
-					{
-						for (int i = offset + minSize; i < offset + count; i++)
-						{
-							buffer[i] = 0f;
-						}
-					}
-				}
+                    // Fill silence if needed
+                    if (minSize < count)
+                    {
+                        for (int i = offset + minSize; i < offset + count; i++)
+                        {
+                            buffer[i] = 0f;
+                        }
+                    }
+                }
 
-				return count;
+                return count;
             }
             catch
             {

--- a/AudioBridgeRenderer.csproj
+++ b/AudioBridgeRenderer.csproj
@@ -43,7 +43,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="InterprocessLib.Unity">
-        <HintPath>$(GamePath)Renderer\BepInEx\plugins\Nytra-InterprocessLib\plugins\InterprocessLib.BepInEx\InterprocessLib.Unity.dll</HintPath>
+        <HintPath>$(GamePath)Renderer\BepInEx\plugins\Nytra-InterprocessLib\InterprocessLib.BepInEx\InterprocessLib.Unity.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="Renderite.Shared">

--- a/AudioBridgeRenderer.csproj
+++ b/AudioBridgeRenderer.csproj
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <GamePath Condition="Exists('/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/')">/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/</GamePath>
     <GamePath Condition="Exists('G:\SteamLibrary\steamapps\common\Resonite\')">G:\SteamLibrary\steamapps\common\Resonite\</GamePath>
-    <PluginTargetDir>$(GamePath)Renderer\BepInEx\plugins\$(AssemblyName)</PluginTargetDir>
+    <PluginTargetDir>$(GamePath)Renderer/BepInEx/plugins/$(AssemblyName)</PluginTargetDir>
   </PropertyGroup>
 
   <ItemGroup>
@@ -43,7 +43,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="InterprocessLib.Unity">
-        <HintPath>$(GamePath)Renderer\BepInEx\plugins\Nytra-InterprocessLib\InterprocessLib.BepInEx\InterprocessLib.Unity.dll</HintPath>
+        <HintPath>$(GamePath)Renderer/BepInEx/plugins/Nytra-InterprocessLib/InterprocessLib.BepInEx/InterprocessLib.Unity.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="Renderite.Shared">

--- a/AudioBridgeRenderer.csproj
+++ b/AudioBridgeRenderer.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>AudioBridgeRenderer</AssemblyName>
     <RootNamespace>AudioBridge.Renderer</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <CopyToPlugins>true</CopyToPlugins>
   </PropertyGroup>
   
   <ItemGroup>
@@ -13,8 +14,10 @@
     <Compile Include="AudioBridgeRenderer.cs" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(GamePath)'==''">
-    <GamePath>/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/</GamePath>
+  <PropertyGroup>
+    <GamePath Condition="Exists('/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/')">/mnt/c/Program Files (x86)/Steam/steamapps/common/Resonite/</GamePath>
+    <GamePath Condition="Exists('G:\SteamLibrary\steamapps\common\Resonite\')">G:\SteamLibrary\steamapps\common\Resonite\</GamePath>
+    <PluginTargetDir>$(GamePath)Renderer\BepInEx\plugins\$(AssemblyName)</PluginTargetDir>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,11 +42,28 @@
       <HintPath>$(GamePath)Renderer/Renderite.Renderer_Data/Managed/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    
+    <Reference Include="InterprocessLib.Unity">
+        <HintPath>$(GamePath)Renderer\BepInEx\plugins\Nytra-InterprocessLib\plugins\InterprocessLib.BepInEx\InterprocessLib.Unity.dll</HintPath>
+        <Private>False</Private>
+    </Reference>
+    <Reference Include="Renderite.Shared">
+        <HintPath>$(GamePath)Renderer/Renderite.Renderer_Data/Managed/Renderite.Shared.dll</HintPath>
+        <Private>False</Private>
+    </Reference>
     <!-- CSCore (copy to plugin folder) -->
     <Reference Include="CSCore">
       <HintPath>$(GamePath)CSCore.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
+  
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+        <ItemGroup>
+            <PluginFiles Include="$(TargetPath)" />
+            <PluginFiles Include="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
+        </ItemGroup>
+        
+        <Copy SourceFiles="@(PluginFiles)" DestinationFolder="$(PluginTargetDir)" Condition="'$(CopyToPlugins)' == 'true'" />
+        <Message Text="Copied plugin files to $(PluginTargetDir)" Importance="high" Condition="'$(CopyToPlugins)' == 'true'" />
+    </Target>
 </Project>


### PR DESCRIPTION
This rewrites the plugin to use InterprocessLib which simplifies the code a lot. I have also gone through and made various improvements to the plugin to make it work more reliably such as removing the delays. Now even when I stress-test it by rapidly changing the config values it doesn't break.

This also bumps the version to 3.0.0 and adds my name to the authors in csproj.

(When uploading to Thunderstore you'll need to add InterprocessLib to the dependencies)

closes #4 